### PR TITLE
FEAT: Level 2 - Restaurant Integration and Many-to-Many Relationship Changes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,3 +43,6 @@ RSpecRails/InferredSpecType:
 
 Naming/MemoizedInstanceVariableName:
   Enabled: false
+
+Rails/I18nLocaleTexts:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -9,12 +9,24 @@ A Rails API for managing restaurant menus and menu items, as part of a coding ch
 ## Features
 
 - [x] Level 1
-- Manage restaurant menus and their items
-- CRUD endpoints for `Menu` and `MenuItem`
-- Assign a menu item to a specific menu
-- Validations for required attributes
-- Structured JSON responses using serializers
-- Comprehensive test coverage with RSpec
+    - Manage restaurant menus and their items
+    - CRUD endpoints for `Menu` and `MenuItem`
+    - Assign a menu item to a specific menu
+    - Validations for required attributes
+    - Structured JSON responses using serializers
+    - Comprehensive test coverage with RSpec
+
+
+- [x] Level 2
+    - Register restaurants and assign multiple menus to each restaurant
+    - Create `MenuItems` and associate them with multiple menus as needed
+    - CRUD endpoints for `Restaurant`, `Menu` and `MenuItems`
+    - List all `Restaurants`, `Menus`, and `MenuItems`
+    - List all menus of a specific `Restaurant`
+    - List all menu items of a specific `Menu`
+    - List all menus a specific `MenuItem` belongs to
+    - Validations for unique `MenuItem` names and `Menu` names within a given `Restaurant`
+    - Even more tests to verify functionalities
 
 ___
 
@@ -62,23 +74,34 @@ ___
 
 ## Endpoints
 
+### Restaurants
+
+| Method | Path             | Description                                 |
+|--------|------------------|---------------------------------------------|
+| GET    | /restaurants     | List all restaurants and the menus they own |
+| GET    | /restaurants/:id | Show a single restaurant and its menus      |
+| POST   | /restaurants     | Create a new restaurant                     |
+| PATCH  | /restaurants/:id | Update a restaurant                         |
+| DELETE | /restaurants/:id | Delete a restaurant                         |
+
 ### Menus
 
-| Method | Path       | Description        |
-|--------|------------|--------------------|
-| GET    | /menus     | List all menus     |
-| GET    | /menus/:id | Show a single menu |
-| POST   | /menus     | Create a new menu  |
-| PATCH  | /menus/:id | Update a menu      |
-| DELETE | /menus/:id | Delete a menu      |
+| Method | Path             | Description              |
+|--------|------------------|--------------------------|
+| GET    | /menus           | List all menus           |
+| GET    | /menus/:id       | Show a single menu       |
+| GET    | /menus/:id/items | List all items in a menu |
+| POST   | /menus           | Create a new menu        |
+| PATCH  | /menus/:id       | Update a menu            |
+| DELETE | /menus/:id       | Delete a menu            |
 
 ### MenuItems
 
-| Method | Path                                    | Description                           |
-|--------|-----------------------------------------|---------------------------------------|
-| GET    | /menu_items                             | List all menu items                   |
-| GET    | /menu_items/:id                         | Show a single menu item               |
-| POST   | /menu_items                             | Create a new menu item                |
-| PATCH  | /menu_items/:id                         | Update a menu item                    |
-| DELETE | /menu_items/:id                         | Delete a menu item                    |
-| POST   | /menu_items/:id/assign_to_menu/:menu_id | Assign a menu item to a specific menu |
+| Method | Path                                    | Description                                         |
+|--------|-----------------------------------------|-----------------------------------------------------|
+| GET    | /menu_items                             | List all menu items and the menus they belong to    |
+| GET    | /menu_items/:id                         | Show a single menu item and the menus it belongs to |
+| POST   | /menu_items                             | Create a new menu item                              |
+| POST   | /menu_items/:id/assign_to_menu/:menu_id | Assign a menu item to a specific menu               |
+| PATCH  | /menu_items/:id                         | Update a menu item                                  |
+| DELETE | /menu_items/:id                         | Delete a menu item                                  |

--- a/app/controllers/menu_items_controller.rb
+++ b/app/controllers/menu_items_controller.rb
@@ -41,12 +41,11 @@ class MenuItemsController < ApplicationController
       "--- Assigning MenuItem (##{@menu_item.id} - #{@menu_item.name}) to Menu (##{@menu.id} - #{@menu.name}) ---"
     )
 
-    @menu_item.menu = @menu
-
-    if @menu_item.save
-      render json: @menu_item, status: :ok
+    if @menu_item.menus.exists?(@menu.id)
+      render json: { message: 'MenuItem is already assigned to this Menu' }, status: :conflict
     else
-      render json: { errors: @menu_item.errors.full_messages }, status: :unprocessable_entity
+      @menu_item.menus << @menu
+      render json: @menu_item, status: :ok
     end
   end
 

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class MenusController < ApplicationController
-  before_action :set_menu, only: %i[show update destroy]
+  before_action :set_menu, only: %i[show items update destroy]
 
   def index
     menus = Menu.all
@@ -10,6 +10,10 @@ class MenusController < ApplicationController
 
   def show
     render json: @menu
+  end
+
+  def items
+    render json: @menu.menu_items
   end
 
   def create

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -46,6 +46,6 @@ class MenusController < ApplicationController
   end
 
   def menu_params
-    params.require(:menu).permit(:name, :description)
+    params.require(:menu).permit(:name, :description, :restaurant_id)
   end
 end

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class RestaurantsController < ApplicationController
+  before_action :set_restaurant, only: %i[show update destroy]
+
+  def index
+    @restaurants = Restaurant.all
+    render json: @restaurants
+  end
+
+  def show
+    render json: @restaurant
+  end
+
+  def create
+    restaurant = Restaurant.new(restaurant_params)
+
+    if restaurant.save
+      render json: restaurant, status: :created
+    else
+      render json: restaurant.errors, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @restaurant.update(restaurant_params)
+      render json: @restaurant
+    else
+      render json: @restaurant.errors, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @restaurant.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_restaurant
+    @restaurant = Restaurant.find(params[:id])
+  end
+
+  def restaurant_params
+    params.require(:restaurant).permit(:name, :address)
+  end
+end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -3,5 +3,6 @@
 class Menu < ApplicationRecord
   validates :name, presence: true
 
-  has_many :menu_items, dependent: :nullify
+  has_many :menu_entries, dependent: :destroy
+  has_many :menu_items, through: :menu_entries
 end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 class Menu < ApplicationRecord
+  # rubocop:disable Rails/UniqueValidationWithoutIndex
   validates :name, presence: true, uniqueness: {
     scope: :restaurant_id,
     case_sensitive: false,
     message: 'Menu name must be unique within the same restaurant'
   }
+  # rubocop:enable Rails/UniqueValidationWithoutIndex
 
   belongs_to :restaurant
   has_many :menu_entries, dependent: :destroy

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 
 class Menu < ApplicationRecord
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: {
+    scope: :restaurant_id,
+    case_sensitive: false,
+    message: 'Menu name must be unique within the same restaurant'
+  }
 
+  belongs_to :restaurant
   has_many :menu_entries, dependent: :destroy
   has_many :menu_items, through: :menu_entries
 end

--- a/app/models/menu_entry.rb
+++ b/app/models/menu_entry.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class MenuEntry < ApplicationRecord
+  belongs_to :menu
+  belongs_to :menu_item
+end

--- a/app/models/menu_item.rb
+++ b/app/models/menu_item.rb
@@ -4,5 +4,6 @@ class MenuItem < ApplicationRecord
   validates :name, presence: true
   validates :price, presence: true, numericality: { greater_than_or_equal_to: 0 }
 
-  belongs_to :menu, optional: true
+  has_many :menu_entries, dependent: :destroy
+  has_many :menus, through: :menu_entries
 end

--- a/app/models/menu_item.rb
+++ b/app/models/menu_item.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class MenuItem < ApplicationRecord
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
   validates :price, presence: true, numericality: { greater_than_or_equal_to: 0 }
 
   has_many :menu_entries, dependent: :destroy

--- a/app/models/menu_item.rb
+++ b/app/models/menu_item.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class MenuItem < ApplicationRecord
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
   validates :price, presence: true, numericality: { greater_than_or_equal_to: 0 }
 
   has_many :menu_entries, dependent: :destroy

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Restaurant < ApplicationRecord
+  validates :name, presence: true
+
+  has_many :menus, dependent: :destroy
+end

--- a/app/serializers/menu_item_serializer.rb
+++ b/app/serializers/menu_item_serializer.rb
@@ -2,7 +2,7 @@
 
 class MenuItemSerializer < ActiveModel::Serializer
   attributes :id, :name, :description, :price
-  has_one :menu
+  has_many :menus
 
   def price
     format('%.2f', object.price)

--- a/app/serializers/restaurant_serializer.rb
+++ b/app/serializers/restaurant_serializer.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class RestaurantSerializer < ActiveModel::Serializer
+  attributes :id, :name
+  has_many :menus
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "posts#index"
 
+  resources :restaurants
+
   resources :menus
   get '/menus/:id/items', to: 'menus#items'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   # root "posts#index"
 
   resources :menus
+  get '/menus/:id/items', to: 'menus#items'
 
   resources :menu_items, only: %i[index show create update destroy]
   post 'menu_items/:id/assign_to_menu/:menu_id', to: 'menu_items#assign_to_menu', as: 'assign_to_menu'

--- a/db/migrate/20250406022024_create_menu_entries.rb
+++ b/db/migrate/20250406022024_create_menu_entries.rb
@@ -1,0 +1,10 @@
+class CreateMenuEntries < ActiveRecord::Migration[8.0]
+  def change
+    create_table :menu_entries do | t |
+      t.references :menu, null: false, foreign_key: true
+      t.references :menu_item, null: false, foreign_key: true
+    end
+    
+    add_index :menu_entries, [ :menu_id, :menu_item_id ], unique: true
+  end
+end

--- a/db/migrate/20250406022638_remove_menu_id_from_menu_items.rb
+++ b/db/migrate/20250406022638_remove_menu_id_from_menu_items.rb
@@ -1,0 +1,5 @@
+class RemoveMenuIdFromMenuItems < ActiveRecord::Migration[8.0]
+  def change
+    remove_reference :menu_items, :menu, foreign_key: true
+  end
+end

--- a/db/migrate/20250406023558_add_unique_index_to_menu_item_name.rb
+++ b/db/migrate/20250406023558_add_unique_index_to_menu_item_name.rb
@@ -1,5 +1,0 @@
-class AddUniqueIndexToMenuItemName < ActiveRecord::Migration[8.0]
-  def change
-    add_index :menu_items, :name, unique: true
-  end
-end

--- a/db/migrate/20250406023558_add_unique_index_to_menu_item_name.rb
+++ b/db/migrate/20250406023558_add_unique_index_to_menu_item_name.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToMenuItemName < ActiveRecord::Migration[8.0]
+  def change
+    add_index :menu_items, :name, unique: true
+  end
+end

--- a/db/migrate/20250406033729_add_case_insensitive_unique_index_to_menu_items_name.rb
+++ b/db/migrate/20250406033729_add_case_insensitive_unique_index_to_menu_items_name.rb
@@ -1,0 +1,5 @@
+class AddCaseInsensitiveUniqueIndexToMenuItemsName < ActiveRecord::Migration[8.0]
+  def change
+    add_index :menu_items, 'LOWER(name)', unique: true, name: 'index_menu_items_on_lower_name'
+  end
+end

--- a/db/migrate/20250406050708_create_restaurants.rb
+++ b/db/migrate/20250406050708_create_restaurants.rb
@@ -1,0 +1,9 @@
+class CreateRestaurants < ActiveRecord::Migration[8.0]
+  def change
+    create_table :restaurants do | t |
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250406050727_add_restaurant_id_to_menus.rb
+++ b/db/migrate/20250406050727_add_restaurant_id_to_menus.rb
@@ -1,0 +1,5 @@
+class AddRestaurantIdToMenus < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :menus, :restaurant, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20250406053206_add_unique_constraint_to_menus.rb
+++ b/db/migrate/20250406053206_add_unique_constraint_to_menus.rb
@@ -1,0 +1,7 @@
+class AddUniqueConstraintToMenus < ActiveRecord::Migration[8.0]
+  def change
+    def change
+      add_index :menus, [ 'LOWER(name)', :restaurant_id ], unique: true, name: 'index_menus_on_lower_name_and_restaurant_id'
+    end
+  end
+end

--- a/db/migrate/20250406053206_add_unique_constraint_to_menus.rb
+++ b/db/migrate/20250406053206_add_unique_constraint_to_menus.rb
@@ -1,7 +1,5 @@
 class AddUniqueConstraintToMenus < ActiveRecord::Migration[8.0]
   def change
-    def change
-      add_index :menus, [ 'LOWER(name)', :restaurant_id ], unique: true, name: 'index_menus_on_lower_name_and_restaurant_id'
-    end
+    add_index :menus, [ 'LOWER(name)', :restaurant_id ], unique: true, name: 'index_menus_on_lower_name_and_restaurant_id'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_06_023558) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_06_033729) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -28,7 +28,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_06_023558) do
     t.decimal "price"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["name"], name: "index_menu_items_on_name", unique: true
+    t.index "lower((name)::text)", name: "index_menu_items_on_lower_name", unique: true
   end
 
   create_table "menus", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_06_033729) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_06_053206) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -36,8 +36,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_06_033729) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "restaurant_id", null: false
+    t.index ["restaurant_id"], name: "index_menus_on_restaurant_id"
+  end
+
+  create_table "restaurants", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   add_foreign_key "menu_entries", "menu_items"
   add_foreign_key "menu_entries", "menus"
+  add_foreign_key "menus", "restaurants"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_05_201930) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_06_022638) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "menu_entries", force: :cascade do |t|
+    t.bigint "menu_id", null: false
+    t.bigint "menu_item_id", null: false
+    t.index ["menu_id", "menu_item_id"], name: "index_menu_entries_on_menu_id_and_menu_item_id", unique: true
+    t.index ["menu_id"], name: "index_menu_entries_on_menu_id"
+    t.index ["menu_item_id"], name: "index_menu_entries_on_menu_item_id"
+  end
 
   create_table "menu_items", force: :cascade do |t|
     t.string "name"
     t.text "description"
     t.decimal "price"
-    t.bigint "menu_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["menu_id"], name: "index_menu_items_on_menu_id"
   end
 
   create_table "menus", force: :cascade do |t|
@@ -31,5 +37,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_05_201930) do
     t.datetime "updated_at", null: false
   end
 
-  add_foreign_key "menu_items", "menus"
+  add_foreign_key "menu_entries", "menu_items"
+  add_foreign_key "menu_entries", "menus"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_06_022638) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_06_023558) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -28,6 +28,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_06_022638) do
     t.decimal "price"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_menu_items_on_name", unique: true
   end
 
   create_table "menus", force: :cascade do |t|

--- a/spec/controllers/menu_items_controller_spec.rb
+++ b/spec/controllers/menu_items_controller_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe MenuItemsController, type: :controller do
 
     it { is_expected.to have_http_status(:ok) }
 
-    it 'returns JSON with array' do
+    it 'returns serialized content' do
       json = response.parsed_body
-      expect(json).to contain_exactly(serialized_menu_item(menu_item))
+      expect(json).to eq([serialized_menu_item(menu_item)])
     end
   end
 

--- a/spec/controllers/menu_items_controller_spec.rb
+++ b/spec/controllers/menu_items_controller_spec.rb
@@ -220,6 +220,24 @@ RSpec.describe MenuItemsController, type: :controller do
           expect(reloaded_menus_list.where(id: menu.id).count).to eq(1)
         end
       end
+
+      context 'when the same menu_item is assigned to multiple menus' do
+        let(:another_menu) { create(:menu) }
+
+        before do
+          post :assign_to_menu, params: { id: menu_item.id, menu_id: another_menu.id }
+        end
+
+        it { is_expected.to have_http_status(:ok) }
+
+        it 'adds the menu_item to the second menu' do
+          expect(menu_item.reload.menus).to include(another_menu)
+        end
+
+        it 'does not remove the previous menu association' do
+          expect(menu_item.reload.menus).to include(menu)
+        end
+      end
     end
 
     context 'when menu_item does not exist' do

--- a/spec/controllers/menu_items_controller_spec.rb
+++ b/spec/controllers/menu_items_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe MenuItemsController, type: :controller do
   describe 'POST #create' do
     subject { response }
 
-    context 'with valid attributes' do
+    context 'when attributes are valid' do
       let(:attributes) { attributes_for(:menu_item) }
 
       before { post :create, params: { menu_item: attributes } }
@@ -56,7 +56,7 @@ RSpec.describe MenuItemsController, type: :controller do
       end
     end
 
-    context 'with invalid attributes' do
+    context 'when attributes are invalid' do
       context 'when name is not present' do
         before { post :create, params: { menu_item: { name: nil } } }
 
@@ -64,6 +64,19 @@ RSpec.describe MenuItemsController, type: :controller do
 
         it 'does not save the item' do
           expect(MenuItem.count).to eq(0)
+        end
+      end
+
+      context 'when name is not unique (case insensitive)' do
+        before do
+          create(:menu_item, name: 'Coffee')
+          post :create, params: { menu_item: { name: 'coFFEe', price: 99.99 } }
+        end
+
+        it { is_expected.to have_http_status(:unprocessable_entity) }
+
+        it 'does not save the item' do
+          expect(MenuItem.count).to eq(1)
         end
       end
 
@@ -94,7 +107,7 @@ RSpec.describe MenuItemsController, type: :controller do
 
     let!(:item) { create(:menu_item, :pancake) }
 
-    context 'with valid attributes' do
+    context 'when attributes are valid' do
       before { patch :update, params: { id: item.id, menu_item: { name: 'New Pancake' } } }
 
       it { is_expected.to have_http_status(:ok) }
@@ -104,9 +117,22 @@ RSpec.describe MenuItemsController, type: :controller do
       end
     end
 
-    context 'with invalid attributes' do
+    context 'when attributes are invalid' do
       context 'when name is blank' do
         before { patch :update, params: { id: item.id, menu_item: { name: '' } } }
+
+        it { is_expected.to have_http_status(:unprocessable_entity) }
+
+        it 'does not change the name' do
+          expect(item.reload.name).to eq('Pancake')
+        end
+      end
+
+      context 'when name is not unique (case insensitive)' do
+        before do
+          create(:menu_item, name: 'Coffee')
+          patch :update, params: { id: item.id, menu_item: { name: 'coFFEe' } }
+        end
 
         it { is_expected.to have_http_status(:unprocessable_entity) }
 

--- a/spec/controllers/menus_controller_spec.rb
+++ b/spec/controllers/menus_controller_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe MenusController, type: :controller do
     context 'when the menu has associated menu_items' do
       let(:reloaded_menu_item) { MenuItem.find(menu_item.id) }
 
-      let!(:menu_item) { create(:menu_item, menu: menu) }
+      let!(:menu_item) { create(:menu_item) }
 
       before { delete :destroy, params: { id: menu.id } }
 
@@ -142,8 +142,8 @@ RSpec.describe MenusController, type: :controller do
         expect { reloaded_menu_item }.not_to raise_error
       end
 
-      it 'nullifies the menu_id in the associated menu_items' do
-        expect(reloaded_menu_item.menu_id).to be_nil
+      it 'removes the menu from menu_item.menus list' do
+        expect(reloaded_menu_item.menus).not_to include(menu)
       end
     end
 

--- a/spec/controllers/menus_controller_spec.rb
+++ b/spec/controllers/menus_controller_spec.rb
@@ -12,14 +12,8 @@ RSpec.describe MenusController, type: :controller do
 
     it { is_expected.to have_http_status(:ok) }
 
-    it 'returns JSON with array' do
-      json = response.parsed_body
-      expect(json).to contain_exactly(serialized_menu(menu))
-    end
-
     it 'returns serialized content' do
       json = response.parsed_body
-
       expect(json).to eq([serialized_menu(menu)])
     end
   end

--- a/spec/controllers/menus_controller_spec.rb
+++ b/spec/controllers/menus_controller_spec.rb
@@ -47,6 +47,36 @@ RSpec.describe MenusController, type: :controller do
     end
   end
 
+  describe 'GET #items' do
+    subject { response }
+
+    context 'when menu exists' do
+      let!(:menu) { create(:menu) }
+
+      before do
+        menu_item1 = create(:menu_item)
+        menu_item2 = create(:menu_item)
+        menu.menu_items << menu_item1
+        menu.menu_items << menu_item2
+        get :items, params: { id: menu.id }
+      end
+
+      it { is_expected.to have_http_status(:ok) }
+
+      it 'returns an array of serialized menu items' do
+        json = response.parsed_body
+        serialized_items = menu.menu_items.map { |item| serialized_menu_item(item) }
+        expect(json).to eq(serialized_items)
+      end
+    end
+
+    context 'when menu does not exist' do
+      before { get :items, params: { id: 'imaginary-id' } }
+
+      it { is_expected.to have_http_status(:not_found) }
+    end
+  end
+
   describe 'POST #create' do
     subject { response }
 

--- a/spec/controllers/restaurants_controller_spec.rb
+++ b/spec/controllers/restaurants_controller_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RestaurantsController, type: :controller do
+  describe 'GET #index' do
+    subject { response }
+
+    let!(:restaurant) { create(:restaurant) }
+
+    before { get :index }
+
+    it { is_expected.to have_http_status(:ok) }
+
+    it 'returns serialized content' do
+      json = response.parsed_body
+      expect(json).to eq([serialized_restaurant(restaurant)])
+    end
+  end
+
+  describe 'GET #show' do
+    subject { response }
+
+    context 'when restaurant exists' do
+      let!(:restaurant) { create(:restaurant) }
+
+      before { get :show, params: { id: restaurant.id } }
+
+      it { is_expected.to have_http_status(:ok) }
+
+      it 'returns serialized content' do
+        json = response.parsed_body
+        expect(json).to eq(serialized_restaurant(restaurant))
+      end
+    end
+
+    context 'when restaurant does not exist' do
+      before { get :show, params: { id: 'imaginary-id' } }
+
+      it { is_expected.to have_http_status(:not_found) }
+    end
+  end
+
+  describe 'POST #create' do
+    subject { response }
+
+    context 'when attributes are valid' do
+      let(:restaurant_attributes) { attributes_for(:restaurant) }
+
+      before { post :create, params: { restaurant: restaurant_attributes } }
+
+      it { is_expected.to have_http_status(:created) }
+
+      it 'returns serialized content' do
+        json = response.parsed_body
+        expect(json).to eq(serialized_restaurant(Restaurant.last))
+      end
+    end
+
+    context 'when attributes are invalid' do
+      context 'when name is missing' do
+        let(:restaurant_attributes) { attributes_for(:restaurant, name: nil) }
+
+        before { post :create, params: { restaurant: restaurant_attributes } }
+
+        it { is_expected.to have_http_status(:unprocessable_entity) }
+
+        it 'does not save the restaurant' do
+          expect(Restaurant.count).to eq(0)
+        end
+      end
+    end
+  end
+
+  describe 'PATCH #update' do
+    subject { response }
+
+    context 'when attributes are valid' do
+      let!(:restaurant) { create(:restaurant) }
+
+      before { patch :update, params: { id: restaurant.id, restaurant: { name: 'La Bodega' } } }
+
+      it { is_expected.to have_http_status(:ok) }
+
+      it 'returns serialized content' do
+        json = response.parsed_body
+        expect(json).to eq(serialized_restaurant(Restaurant.last))
+      end
+    end
+
+    context 'when attributes are invalid' do
+      let!(:restaurant) { create(:restaurant) }
+
+      context 'when name is missing' do
+        before { patch :update, params: { id: restaurant.id, restaurant: { name: '' } } }
+
+        it { is_expected.to have_http_status(:unprocessable_entity) }
+
+        it 'does not change the name' do
+          expect(restaurant.reload.name).not_to eq('')
+        end
+      end
+    end
+
+    context 'when restaurant does not exist' do
+      before { patch :update, params: { id: 'imaginary-id', restaurant: { name: 'Anything' } } }
+
+      it { is_expected.to have_http_status(:not_found) }
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    subject { response }
+
+    let!(:restaurant) { create(:restaurant) }
+    let!(:menu) { create(:menu, restaurant: restaurant) }
+
+    context 'when restaurant exists' do
+      before { delete :destroy, params: { id: restaurant.id } }
+
+      it { is_expected.to have_http_status(:no_content) }
+
+      it 'removes the restaurant from the database' do
+        expect(Restaurant).not_to exist(restaurant.id)
+      end
+
+      it 'removes the associated menus' do
+        expect(Menu).not_to exist(menu.id)
+      end
+    end
+
+    context 'when restaurant does not exist' do
+      before { delete :destroy, params: { id: 'imaginary-id' } }
+
+      it { is_expected.to have_http_status(:not_found) }
+    end
+  end
+end

--- a/spec/factories/menus.rb
+++ b/spec/factories/menus.rb
@@ -4,15 +4,18 @@ FactoryBot.define do
   factory :menu do
     name { Faker::Food.ethnic_category }
     description { Faker::Food.description }
+    restaurant
 
     trait :pizza do
       name { 'Pizzas' }
       description { 'You can never go wrong with a good Italian pizza with cheese and cheese and more cheese.' }
+      restaurant
     end
 
     trait :sushi do
       name { 'Sushi' }
       description { 'Expensive but delicious. Soaking it in soy sauce is optional.' }
+      restaurant
     end
   end
 end

--- a/spec/factories/restaurants.rb
+++ b/spec/factories/restaurants.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :restaurant do
+    name { Faker::Restaurant.name }
+  end
+end

--- a/spec/models/menu_item_spec.rb
+++ b/spec/models/menu_item_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe MenuItem, type: :model do
     it { is_expected.to be_valid }
 
     context 'when menu is not associated' do
-      subject { build(:menu_item, menu: nil) }
+      subject { build(:menu_item) }
 
       it { is_expected.to be_valid }
     end

--- a/spec/models/menu_item_spec.rb
+++ b/spec/models/menu_item_spec.rb
@@ -7,17 +7,27 @@ RSpec.describe MenuItem, type: :model do
     subject { build(:menu_item) }
 
     it { is_expected.to be_valid }
-
-    context 'when menu is not associated' do
-      subject { build(:menu_item) }
-
-      it { is_expected.to be_valid }
-    end
   end
 
   context 'when attributes are invalid' do
     context 'when name is not present' do
       subject { build(:menu_item, name: '') }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when name is not unique' do
+      subject { build(:menu_item, name: 'Coffee') }
+
+      before { create(:menu_item, name: 'Coffee') }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when name is not unique (case insensitive)' do
+      subject { build(:menu_item, name: 'CoFfEe') }
+
+      before { create(:menu_item, name: 'coffee') }
 
       it { is_expected.not_to be_valid }
     end

--- a/spec/models/menu_spec.rb
+++ b/spec/models/menu_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe Menu, type: :model do
 
         it { is_expected.not_to be_valid }
       end
+
+      context 'when name is duplicated within the same restaurant' do
+        subject { build(:menu, name: 'Italian food', restaurant: existing_menu.restaurant) }
+
+        let!(:existing_menu) { create(:menu, name: 'Italian food', restaurant: build(:restaurant)) }
+
+        it { is_expected.not_to be_valid }
+      end
     end
   end
 end

--- a/spec/models/restaurant_spec.rb
+++ b/spec/models/restaurant_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Restaurant, type: :model do
+  context 'when attributes are valid' do
+    subject { build(:restaurant) }
+
+    it { is_expected.to be_valid }
+
+    context 'when name is empty' do
+      subject { build(:restaurant, name: '') }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when restaurant has menus' do
+      subject { restaurant.menus }
+
+      let!(:restaurant) { create(:restaurant, menus: [create(:menu)]) }
+
+      it { is_expected.not_to be_empty }
+    end
+  end
+
+  context 'when attributes are invalid' do
+    context 'when name is empty' do
+      subject { build(:restaurant, name: '') }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+end

--- a/spec/support/serializer_helpers.rb
+++ b/spec/support/serializer_helpers.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 module SerializerHelpers
+  def serialized_restaurant(restaurant)
+    {
+      id: restaurant.id,
+      name: restaurant.name,
+      menus: restaurant.menus.map { |menu| serialized_menu(menu) }
+    }.as_json
+  end
+
   def serialized_menu(menu)
     {
       id: menu.id,

--- a/spec/support/serializer_helpers.rb
+++ b/spec/support/serializer_helpers.rb
@@ -15,7 +15,7 @@ module SerializerHelpers
       name: menu_item.name,
       description: menu_item.description,
       price: format('%.2f', menu_item.price),
-      menu: menu_item.menu ? serialized_menu(menu_item.menu) : nil
+      menus: menu_item.menus.map { |menu| serialized_menu(menu) }
     }.as_json
   end
 end


### PR DESCRIPTION
## Description

### Objective

This PR introduces the Restaurant model, establishes a many-to-many relationship between Menu and MenuItem, enforces unique MenuItem names, and adds necessary endpoints and tests.

___

### Technical Details

To implement the second level of this challenge, the following tasks were completed in this PR:

**Object Model:**
- Created the `Restaurant` model and established the `Restaurant has_many Menu` relationship.
- Refactored the `Menu` and `MenuItem` models/controllers to implement a many-to-many relationship.
- Added a unique constraint on `MenuItem` names to prevent duplicates.
- `MenuItem` can now be associated with multiple `Menus`.

**Endpoints:**
- Introduced a route to list all `MenuItems` for a specific `Menu`.
- Created endpoints for CRUD operations on `Restaurant`.

**Validations:**
- Added uniqueness validation to `MenuItem` names.
- Added uniqueness validation to `Menu` names within a given `Restaurant`.

**Serializers:**
- Created a serializer for `Restaurant` to return structured and clean JSON responses.
- Adjusted other serializers to accommodate new changes. 

**Testing:**
- Added and updated model and controller tests for `Restaurant`, `Menu`, and `MenuItem`.
- Verified `MenuItem` uniqueness validation and behavior for multiple associations with menus.
- Added 43 new tests, up to a total of 105 tests.

**Other:**
- Updated the README.md to reflect the new `Restaurant` model and associated endpoints.

___

### Notes for the Evaluator

To start this part of the challenge, I had to think where I would start accommodating this changes.
I've concluded that starting with the Restaurant could've been harder. So I decided to first implement the many-to-many relationship between Menu and MenuItem, creating the join table and updating tests accordingly. I thought that, as the MenuItem and Menu could interact one between the other regardless of the Restaurant, it would be easier.

To visualize everything, I created a simple model of the database, as shown below:
<img width="981" alt="image" src="https://github.com/user-attachments/assets/b54e68a8-e600-4209-8328-a0791f77d268" />

Sadly, there was some ambiguity in the task requirements that needed clarification. “MenuItem can be on multiple Menus of a Restaurant” and “MenuItem names should not be duplicated in the database.” Initially, this seemed to imply that a MenuItem belonged to a specific restaurant, and its name needed to be unique within that scope. However, the global name uniqueness requirement indicated that MenuItem names (e.g., “Pancake”) should be unique across the entire database. I interpreted this as a simplification for promoting reuse. Therefore, I decided that MenuItem should not belong to a specific restaurant and can be shared across menus from different restaurants. This way, two unrelated restaurants can have the same MenuItem (e.g., “Beer”).
This approach aligns with the task requirements while keeping the design flexible for future adjustments. Or, at least, that's what I think.

For the Menu-MenuItem association, I created a join table called menu_entries. The name was chosen for its clarity, as it represents a single entry of a MenuItem into a Menu, making the relationship easier to understand. 

I also relied on the existing test coverage that I did on the Level 1 PR to identify any regressions introduced by this change. 
And it was only when I was writing more tests that I realized that case sensitivity for names had to be considered, so I made some adjustments here and there.
Then I added a route to list all Items in a Menu. It would have been a good thing to add this in Level 1, but it was overlooked ¯\_(ツ)_/¯ sadly

As fot the Restaurant model, I went as simple as possible, and only included `name` as an attribute. However, I added a unique constraint for the Restaurant-Menu pair to prevent a restaurant from having multiple menus with the same name. Even though it wasn't asked for this part of the challenge, it was bothering me that one single restaurant could have two identical menus. As the challenge didn’t prohibit it either, I took this liberty to complicate myself further.
I decided to not do the same thing with the Restaurant itself, as multiple restaurants can share the same name if they have different addresses. Adding a constraint here would complicate the future expansion of this feature.

At the end of the development of this PR, I added additional tests, as expected. However, I’m not aiming for exhaustive testing, as time is a constraint.