### PR TITLE
FEAT: Level 3 - Imports

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,3 +49,6 @@ Rails/I18nLocaleTexts:
 
 Metrics/MethodLength:
   Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,3 +46,6 @@ Naming/MemoizedInstanceVariableName:
 
 Rails/I18nLocaleTexts:
   Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,3 +52,11 @@ Metrics/MethodLength:
 
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
+
+RSpec/ExampleLength:
+  Exclude:
+    - 'spec/services/data_conversion_tool/**/*_spec.rb'
+
+RSpec/MultipleExpectations:
+  Exclude:
+    - 'spec/services/data_conversion_tool/**/*_spec.rb'

--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ A Rails API for managing restaurant menus and menu items, as part of a coding ch
     - Validations for unique `MenuItem` names and `Menu` names within a given `Restaurant`
     - Even more tests to verify functionalities
 
+- [x] Level 3
+    - Import restaurants, menus, and menu items automatically using a JSON file.
+        - This can be achieved through a POST request
+        - Or by using the command-line.
+    - In cases where there are duplicate items within menus during import, the system will automatically rename and
+      duplicate these items, allowing the user to handle them later. This ensures no data loss while maintaining
+      flexibility for future actions.
+    - Import logs are generated with tags for easier assessment.
+    - Logs generated through command-line are color-coded.
+    - Command-line script offers options for silent mode (which suppresses logs) and logs-only mode (which only prints
+      the logs).
+    - More and more tests!
+
 ___
 
 ## Getting Started
@@ -54,7 +67,31 @@ ___
 
 ## Commands
 
-### Lint
+## Import JSON Data
+
+To import restaurant, menu, and menu item data from a JSON file, use the following command:
+
+```bash
+
+bin/import_json path/to/file.json [options]
+
+```
+
+### Options:
+
+- `-h` or `--help`: Show help information about the command.
+- `--silent`: Run in silent mode (no logs, only basic output).
+- `--logs-only`: Print only the logs, ignoring other details like created records and errors.
+
+### Examples:
+
+```bash
+bin/import_json spec/fixtures/files/sample.json
+bin/import_json spec/fixtures/files/sample.json --silent
+bin/import_json spec/fixtures/files/sample.json --logs-only
+```
+
+## Lint
 
 To run the linter, simply use:
 
@@ -62,7 +99,7 @@ To run the linter, simply use:
    bundle exec rubocop
    ```
 
-### Tests
+## Tests
 
 To run the test suite, use:
 
@@ -72,7 +109,15 @@ To run the test suite, use:
 
 ___
 
+---
+
 ## Endpoints
+
+### Import
+
+| Method | Path    | Description                                                   |
+|--------|---------|---------------------------------------------------------------|
+| POST   | /import | Import restaurant, menu, and menu item data from a JSON file. |
 
 ### Restaurants
 
@@ -105,3 +150,67 @@ ___
 | POST   | /menu_items/:id/assign_to_menu/:menu_id | Assign a menu item to a specific menu               |
 | PATCH  | /menu_items/:id                         | Update a menu item                                  |
 | DELETE | /menu_items/:id                         | Delete a menu item                                  |
+
+___
+
+## JSON Format to import files
+
+To successfully import restaurants, menus, and menu items, your JSON file must follow a specific structure. The file
+should contain a list of restaurants, each with its menus and menu items. Below is the structure and the required fields
+for each level:
+
+### Example JSON Structure:
+
+```json
+{
+  "restaurants": [
+    {
+      "name": "Restaurant Name",
+      "description": "Description of the restaurant",
+      "menus": [
+        {
+          "name": "Menu Name",
+          "description": "Description of the menu",
+          "menu_items": [
+            {
+              "name": "Menu Item Name",
+              "price": 10.99,
+              "description": "Description of the menu item"
+            },
+            {
+              "name": "Another Menu Item",
+              "price": 15.99,
+              "description": "Description of another menu item"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Required Fields:
+
+- `restaurants`: An array of restaurant objects.
+    - `name`: The name of the restaurant (required).
+    - `description`: A description of the restaurant (optional, but recommended).
+- `menus`: Each restaurant can have multiple menus.
+    - `name`: The name of the menu (required).
+    - `description`: A description of the menu (optional, but recommended).
+- `menu_items`: Each menu can have multiple menu items.
+    - `name`: The name of the menu item (required).
+    - `price`: The price of the menu item (required, must be a number).
+    - `description`: A description of the menu item (optional, but recommended).
+
+### Limitations:
+
+- **Duplicate Items:** If there are duplicate menu items (i.e., menu items with the same name across menus), the system
+  will automatically rename them by appending a suffix (e.g., “Menu Item Name random-number”). The user will have to
+  decide later whether to keep the duplicates or manually resolve them.
+- **Missing Fields:** Any missing required fields (e.g., name or price for menu items) will result in a skipped record,
+  and an error will be logged.
+- **Price Formatting:** The price field must be a number (e.g., 10.99). Strings or invalid formats will result
+  in a skipped record.
+- **Nested Structures:** The JSON structure must adhere to the hierarchy of restaurants → menus → menu items. Each level
+  must be nested correctly; otherwise, the import will fail.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,26 @@
 # Restaurant API
 
 A Rails API for managing restaurant menus and menu items, as part of a coding challenge.
+___
+
+## Table of Contents
+
+- [Features](#features)
+- [Requirements](#requirements)
+- [Setup Instructions](#getting-started)
+- [Commands](#commands)
+- [Endpoints](#endpoints)
+    - [Import](#import)
+    - [Restaurants](#restaurants)
+    - [Menus](#menus)
+    - [MenuItems](#menuitems)
+- [JSON Format to Import Files](#json-format-to-import-files)
+    - [Example JSON Structure](#example-json-structure)
+    - [Required Fields](#required-fields)
+    - [Limitations](#limitations)
+- [Decision Log (Notion)](#decision-making-log-notion)
+
+___
 
 ## Features
 
@@ -40,6 +60,16 @@ A Rails API for managing restaurant menus and menu items, as part of a coding ch
     - Command-line script offers options for silent mode (which suppresses logs) and logs-only mode (which only prints
       the logs).
     - More and more tests!
+
+___
+
+## Requirements
+
+To run this project, you need the following tools installed:
+
+- [Ruby 3.2.4](https://www.ruby-lang.org/en/documentation/installation/)
+- [Rails 8.0.2](https://guides.rubyonrails.org/getting_started.html)
+- [Docker with Compose](https://docs.docker.com/compose/install/)
 
 ___
 
@@ -108,8 +138,6 @@ To run the test suite, use:
    ```
 
 ___
-
----
 
 ## Endpoints
 
@@ -214,3 +242,14 @@ for each level:
   in a skipped record.
 - **Nested Structures:** The JSON structure must adhere to the hierarchy of restaurants → menus → menu items. Each level
   must be nested correctly; otherwise, the import will fail.
+
+___
+
+## Decision Making Log (Notion)
+
+Here is the link to a summary of the decision-making process during this challenge, documented in Notion.
+
+Some of these thoughts are also written in the project's pull requests, which have not been deleted and can still be
+read there.
+
+[Decision Log on Notion](https://haotran.notion.site/Decision-Making-Restaurant-API-1ceef206b2be80ff8284fb21357f525a?pvs=4)

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -18,9 +18,9 @@ class ImportsController < ApplicationController
     DataConversionTool::RestaurantImporter.import_from_file(@file.tempfile.path)
   end
 
-  def log_errors(e)
-    Rails.logger.error(" ---> [X IMPORT ERROR] #{e.class}: #{e.message}")
-    Rails.logger.error(e.backtrace.join("\n")) if e.backtrace
+  def log_errors(exception)
+    Rails.logger.error(" ---> [X IMPORT ERROR] #{exception.class}: #{exception.message}")
+    Rails.logger.error(exception.backtrace.join("\n")) if exception.backtrace
   end
 
   def uploaded_file

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class ImportsController < ApplicationController
+  before_action :uploaded_file, only: %i[create]
+
+  def create
+    logs = import_from_file
+
+    render json: { logs: logs, status: 'success' }, status: :ok
+  rescue StandardError => e
+    log_errors(e)
+    render json: { error: e.message }, status: :unprocessable_entity
+  end
+
+  private
+
+  def import_from_file
+    DataConversionTool::RestaurantImporter.import_from_file(@file.tempfile.path)
+  end
+
+  def log_errors(e)
+    Rails.logger.error(" ---> [X IMPORT ERROR] #{e.class}: #{e.message}")
+    Rails.logger.error(e.backtrace.join("\n")) if e.backtrace
+  end
+
+  def uploaded_file
+    @file = params.require(:file)
+  end
+end

--- a/app/services/data_conversion_tool/base_importer.rb
+++ b/app/services/data_conversion_tool/base_importer.rb
@@ -1,5 +1,15 @@
 module DataConversionTool
   class BaseImporter
+    include DataConversionTool::Helpers
+
+    attr_reader :logs, :errors, :skipped_keys
+
+    def initialize(logs: nil, errors: nil, skipped_keys: nil)
+      @logs = logs || []
+      @errors = errors || []
+      @skipped_keys = skipped_keys || Set.new
+    end
+
     def self.import_from_file(file_path)
       parsed_json = parse_json(file_path)
       new.import(parsed_json)
@@ -20,6 +30,18 @@ module DataConversionTool
 
     def import(_parsed_json)
       raise NotImplementedError, 'This method needs implementation in a subclass'
+    end
+
+    def summarize_logs
+      unless @errors.empty?
+        @logs << Logs.summarize_warnings_title
+        @logs.concat(@errors)
+      end
+
+      return if @skipped_keys.empty?
+
+      @logs << Logs.unknown_keys_title
+      @logs.concat(@skipped_keys.to_a.sort.map { |k| "  - #{k}" })
     end
   end
 end

--- a/app/services/data_conversion_tool/base_importer.rb
+++ b/app/services/data_conversion_tool/base_importer.rb
@@ -1,0 +1,25 @@
+module DataConversionTool
+  class BaseImporter
+    def self.import_from_file(file_path)
+      parsed_json = parse_json(file_path)
+      new.import(parsed_json)
+    end
+
+    def self.parse_json(file_path)
+      JSON.parse(File.read(file_path))
+    rescue JSON::ParserError => e
+      log_errors(e)
+      raise 'Invalid JSON file'
+    end
+
+    def self.log_errors(e)
+      Rails.logger.error("JSON parsing failed: #{e.message}")
+    end
+
+    # Instance Methods
+
+    def import(_parsed_json)
+      raise NotImplementedError, 'This method needs implementation in a subclass'
+    end
+  end
+end

--- a/app/services/data_conversion_tool/base_importer.rb
+++ b/app/services/data_conversion_tool/base_importer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DataConversionTool
   class BaseImporter
     include DataConversionTool::Helpers
@@ -22,8 +24,8 @@ module DataConversionTool
       raise 'Invalid JSON file'
     end
 
-    def self.log_errors(e)
-      Rails.logger.error("JSON parsing failed: #{e.message}")
+    def self.log_errors(exception)
+      Rails.logger.error("JSON parsing failed: #{exception.message}")
     end
 
     # Instance Methods

--- a/app/services/data_conversion_tool/base_importer.rb
+++ b/app/services/data_conversion_tool/base_importer.rb
@@ -14,7 +14,8 @@ module DataConversionTool
       @created_records = created_records || {
         restaurants: 0,
         menus: 0,
-        items: 0
+        items: 0,
+        duplicated_items: 0
       }
 
       @skipped_records = skipped_records || {

--- a/app/services/data_conversion_tool/base_importer.rb
+++ b/app/services/data_conversion_tool/base_importer.rb
@@ -6,10 +6,22 @@ module DataConversionTool
 
     attr_reader :logs, :errors, :skipped_keys
 
-    def initialize(logs: nil, errors: nil, skipped_keys: nil)
+    def initialize(logs: nil, errors: nil, skipped_keys: nil, created_records: nil, skipped_records: nil)
       @logs = logs || []
       @errors = errors || []
       @skipped_keys = skipped_keys || Set.new
+
+      @created_records = created_records || {
+        restaurants: 0,
+        menus: 0,
+        items: 0
+      }
+
+      @skipped_records = skipped_records || {
+        restaurants: 0,
+        menus: 0,
+        items: 0
+      }
     end
 
     def self.import_from_file(file_path)

--- a/app/services/data_conversion_tool/helpers/key_finder.rb
+++ b/app/services/data_conversion_tool/helpers/key_finder.rb
@@ -3,12 +3,10 @@
 module DataConversionTool
   module Helpers
     module KeyFinder
-      ALLOWED_ITEM_KEYS = %w[menu_items dishes items pratos plats].freeze
-
-      def self.find(data)
-        key = ALLOWED_ITEM_KEYS.find { |k| data.key?(k) }
+      def self.find(data, allowed_keys:)
+        key = allowed_keys.find { |k| data.key?(k) }
         @unknown_keys ||= Set.new
-        data.each_key { |k| @unknown_keys << k unless ALLOWED_ITEM_KEYS.include?(k) }
+        data.each_key { |k| @unknown_keys << k unless allowed_keys.include?(k) }
         key
       end
 

--- a/app/services/data_conversion_tool/helpers/key_finder.rb
+++ b/app/services/data_conversion_tool/helpers/key_finder.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module DataConversionTool
+  module Helpers
+    module KeyFinder
+      ALLOWED_ITEM_KEYS = %w[menu_items dishes items pratos plats].freeze
+
+      def self.find(data)
+        key = ALLOWED_ITEM_KEYS.find { |k| data.key?(k) }
+        @unknown_keys ||= Set.new
+        data.keys.each { |k| @unknown_keys << k unless ALLOWED_ITEM_KEYS.include?(k) }
+        key
+      end
+
+      def self.unknown_keys
+        @unknown_keys.to_a
+      end
+    end
+  end
+end

--- a/app/services/data_conversion_tool/helpers/key_finder.rb
+++ b/app/services/data_conversion_tool/helpers/key_finder.rb
@@ -8,7 +8,7 @@ module DataConversionTool
       def self.find(data)
         key = ALLOWED_ITEM_KEYS.find { |k| data.key?(k) }
         @unknown_keys ||= Set.new
-        data.keys.each { |k| @unknown_keys << k unless ALLOWED_ITEM_KEYS.include?(k) }
+        data.each_key { |k| @unknown_keys << k unless ALLOWED_ITEM_KEYS.include?(k) }
         key
       end
 

--- a/app/services/data_conversion_tool/helpers/logs.rb
+++ b/app/services/data_conversion_tool/helpers/logs.rb
@@ -9,6 +9,14 @@ module DataConversionTool
         "[✓ SUCCESS] Restaurant '#{name}' imported"
       end
 
+      def restaurant_creation_failed(name, errors)
+        "[X ERROR]️ Failed to create restaurant '#{name}': #{errors}"
+      end
+
+      def restaurant_creation_exception(name, exception)
+        "[X ERROR]️ Unexpected error creating restaurant '#{name}': #{exception}"
+      end
+
       def menu_success(name, restaurant_name)
         "  [✓ SUCCESS] Menu '#{name}' added to '#{restaurant_name}'"
       end
@@ -17,8 +25,12 @@ module DataConversionTool
         "[⚠ WARNING]️ Menu '#{name}' already exists for restaurant '#{restaurant_name}', skipping..."
       end
 
-      def missing_items_key_error(menu_name)
-        "[X ERROR]️ No valid items key found in menu '#{menu_name}'"
+      def self.missing_restaurants_key_error(available_keys)
+        "[X ERROR]️ Missing required root key: 'restaurants'. Please make sure your JSON has one of the following as a top-level key: #{available_keys.join(', ')}"
+      end
+
+      def self.missing_items_key_error(restaurant_name, menu_name, available_keys)
+        "[X ERROR]️ No valid items key found in restaurant '#{restaurant_name}' menu '#{menu_name}'. Available keys: #{available_keys.join(', ')}"
       end
 
       def duplicate_item_warning(name, new_name)
@@ -30,11 +42,11 @@ module DataConversionTool
       end
 
       def summarize_warnings_title
-        "\n--- Import completed with warnings: ---"
+        '--- Import completed with warnings: ---'
       end
 
       def unknown_keys_title
-        "\n--- ⚠ Unknown keys found " \
+        '--- ⚠ Unknown keys found ' \
           '(consider adding them to ALLOWED_ITEM_KEYS ' \
           'in DataConversionTool::Helpers::KeyFinder):'
       end

--- a/app/services/data_conversion_tool/helpers/logs.rb
+++ b/app/services/data_conversion_tool/helpers/logs.rb
@@ -60,6 +60,10 @@ module DataConversionTool
         "[X ERROR]️ Unexpected error creating MenuItem '#{name}' (#{price}): #{exception}"
       end
 
+      def self.orphan_menu_item(name, price)
+        "[X ERROR]️ MenuItem '#{name}' (#{price}) could not be created because its menu was missing"
+      end
+
       def summarize_warnings_title
         '--- Import completed with warnings: ---'
       end

--- a/app/services/data_conversion_tool/helpers/logs.rb
+++ b/app/services/data_conversion_tool/helpers/logs.rb
@@ -25,6 +25,14 @@ module DataConversionTool
         "[⚠ WARNING]️ Menu '#{name}' already exists for restaurant '#{restaurant_name}', skipping..."
       end
 
+      def menu_creation_failed(menu_name, restaurant_name, errors)
+        "[X ERROR]️ Failed to create menu '#{menu_name}' for restaurant '#{restaurant_name}': #{errors}"
+      end
+
+      def menu_creation_exception(menu_name, restaurant_name, exception)
+        "[X ERROR]️ Unexpected error creating menu '#{menu_name}' for restaurant '#{restaurant_name}': #{exception}"
+      end
+
       def self.missing_restaurants_key_error(available_keys)
         "[X ERROR]️ Missing required root key: 'restaurants'. Please make sure your JSON has one of the following as a top-level key: #{available_keys.join(', ')}"
       end
@@ -39,6 +47,14 @@ module DataConversionTool
 
       def menu_item_success(name)
         "    [✓ SUCCESS] MenuItem '#{name}' added"
+      end
+
+      def menu_item_creation_failed(name, price, errors)
+        "[X ERROR]️ Failed to create MenuItem '#{name}' (#{price}): #{errors}"
+      end
+
+      def menu_item_creation_exception(name, price, exception)
+        "[X ERROR]️ Unexpected error creating MenuItem '#{name}' (#{price}): #{exception}"
       end
 
       def summarize_warnings_title

--- a/app/services/data_conversion_tool/helpers/logs.rb
+++ b/app/services/data_conversion_tool/helpers/logs.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module DataConversionTool
+  module Helpers
+    module Logs
+      module_function
+
+      def restaurant_success(name)
+        "[✓ SUCCESS] Restaurant '#{name}' imported"
+      end
+
+      def menu_success(name, restaurant_name)
+        "  [✓ SUCCESS] Menu '#{name}' added to '#{restaurant_name}'"
+      end
+
+      def menu_warning(name, restaurant_name)
+        "[⚠ WARNING]️ Menu '#{name}' already exists for restaurant '#{restaurant_name}', skipping..."
+      end
+
+      def missing_items_key_error(menu_name)
+        "[X ERROR]️ No valid items key found in menu '#{menu_name}'"
+      end
+
+      def duplicate_item_warning(name, new_name)
+        "    [⚠ WARNING]️ Duplicate item '#{name}' renamed to '#{new_name}'"
+      end
+
+      def menu_item_success(name)
+        "    [✓ SUCCESS] MenuItem '#{name}' added"
+      end
+
+      def summarize_warnings_title
+        "\n--- Import completed with warnings: ---"
+      end
+
+      def unknown_keys_title
+        "\n--- ⚠ Unknown keys found (consider adding them to ALLOWED_ITEM_KEYS in DataConversionTool::Helpers::KeyFinder):"
+      end
+
+      def unknown_key_item(key)
+        "  - #{key}"
+      end
+    end
+  end
+end

--- a/app/services/data_conversion_tool/helpers/logs.rb
+++ b/app/services/data_conversion_tool/helpers/logs.rb
@@ -34,11 +34,14 @@ module DataConversionTool
       end
 
       def self.missing_restaurants_key_error(available_keys)
-        "[X ERROR]️ Missing required root key: 'restaurants'. Please make sure your JSON has one of the following as a top-level key: #{available_keys.join(', ')}"
+        "[X ERROR]️ Missing required root key: 'restaurants'." \
+          'Please make sure your JSON has one of the following as a top-level key:' \
+          "#{available_keys.join(', ')}"
       end
 
       def self.missing_items_key_error(restaurant_name, menu_name, available_keys)
-        "[X ERROR]️ No valid items key found in restaurant '#{restaurant_name}' menu '#{menu_name}'. Available keys: #{available_keys.join(', ')}"
+        "[X ERROR]️ No valid items key found in restaurant '#{restaurant_name}' menu '#{menu_name}'." \
+          "Available keys: #{available_keys.join(', ')}"
       end
 
       def duplicate_item_warning(name, new_name)

--- a/app/services/data_conversion_tool/helpers/logs.rb
+++ b/app/services/data_conversion_tool/helpers/logs.rb
@@ -34,7 +34,9 @@ module DataConversionTool
       end
 
       def unknown_keys_title
-        "\n--- ⚠ Unknown keys found (consider adding them to ALLOWED_ITEM_KEYS in DataConversionTool::Helpers::KeyFinder):"
+        "\n--- ⚠ Unknown keys found " \
+          '(consider adding them to ALLOWED_ITEM_KEYS ' \
+          'in DataConversionTool::Helpers::KeyFinder):'
       end
 
       def unknown_key_item(key)

--- a/app/services/data_conversion_tool/menu_importer.rb
+++ b/app/services/data_conversion_tool/menu_importer.rb
@@ -4,8 +4,8 @@ module DataConversionTool
   class MenuImporter < BaseImporter
     ALLOWED_ITEM_KEYS = %w[menu_items items dishes pratos plats].freeze
 
-    def initialize(restaurant:, logs: nil, errors: nil, skipped_keys: nil)
-      super(logs: logs, errors: errors, skipped_keys: skipped_keys)
+    def initialize(restaurant:, created_records: nil, skipped_records: nil, logs: nil, errors: nil, skipped_keys: nil)
+      super(logs: logs, created_records: created_records, skipped_records: skipped_records, errors: errors, skipped_keys: skipped_keys)
       @restaurant = restaurant
     end
 
@@ -14,6 +14,8 @@ module DataConversionTool
       return handle_existing_menu(data['name']) if menu_exists?(data['name'])
 
       menu = create_menu(name: menu_name)
+      return unless menu
+
       items = extract_items_from(data)
       import_items(menu, items) if items
     end
@@ -29,9 +31,21 @@ module DataConversionTool
     end
 
     def create_menu(name:)
-      menu = @restaurant.menus.create!(name: name)
-      logs << Logs.menu_success(name, @restaurant.name)
-      menu
+      menu = @restaurant.menus.new(name: name)
+
+      if menu.save
+        @logs << Logs.menu_success(name, @restaurant.name)
+        @created_records[:menus] += 1
+        return menu
+      else
+        @errors << Logs.menu_creation_failed(name, @restaurant.name, menu.errors.full_messages.to_sentence)
+        @skipped_records[:menus] += 1
+      end
+
+      nil
+    rescue StandardError => e
+      @errors << Logs.menu_creation_exception(name, @restaurant.name, e.message)
+      nil
     end
 
     def extract_items_from(data)
@@ -58,6 +72,8 @@ module DataConversionTool
     def import_items(menu, items)
       item_importer = MenuItemImporter.new(
         menu: menu,
+        created_records: @created_records,
+        skipped_records: @skipped_records,
         logs: logs,
         errors: errors,
         skipped_keys: skipped_keys

--- a/app/services/data_conversion_tool/menu_importer.rb
+++ b/app/services/data_conversion_tool/menu_importer.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module DataConversionTool
+  class MenuImporter < BaseImporter
+    def initialize(restaurant:, logs: nil, errors: nil, skipped_keys: nil)
+      super(logs: logs, errors: errors, skipped_keys: skipped_keys)
+      @restaurant = restaurant
+    end
+
+    def import(data:)
+      menu_name = data['name']
+      return errors << Logs.menu_warning(menu_name, @restaurant.name) if @restaurant.menus.exists?(name: menu_name)
+
+      menu = create_menu(name: menu_name)
+      key = KeyFinder.find(data)
+      return handle_missing_items_key(data.keys) unless key
+
+      items = wrap_in_array(data[key])
+      item_importer = MenuItemImporter.new(
+        menu: menu,
+        logs: logs,
+        errors: errors,
+        skipped_keys: skipped_keys
+      )
+      items.each { |item| item_importer.import(data: item) }
+    end
+
+    private
+
+    def create_menu(name:)
+      menu = @restaurant.menus.create!(name: name)
+      logs << Logs.menu_success(name, @restaurant.name)
+      menu
+    end
+
+    def handle_missing_items_key(keys)
+      errors << Logs.missing_items_key_error
+      skipped_keys.merge(keys - KeyFinder::ALLOWED_ITEM_KEYS)
+    end
+
+    def wrap_in_array(value)
+      value.is_a?(Array) ? value : [value]
+    end
+  end
+end

--- a/app/services/data_conversion_tool/menu_item_importer.rb
+++ b/app/services/data_conversion_tool/menu_item_importer.rb
@@ -2,8 +2,8 @@
 
 module DataConversionTool
   class MenuItemImporter < BaseImporter
-    def initialize(menu:, created_records: nil, skipped_records: nil, logs: nil, errors: nil, skipped_keys: nil)
-      super(logs: logs, created_records: created_records, skipped_records: skipped_records, errors: errors, skipped_keys: skipped_keys)
+    def initialize(menu:, **)
+      super(**)
       @menu = menu
     end
 
@@ -28,9 +28,11 @@ module DataConversionTool
     private
 
     def create_item(name:, price:)
-      item = @menu.menu_items.new(name: name, price: price)
+      item = MenuItem.new(name: name, price: price)
 
       if item.save
+        MenuEntry.create!(menu: @menu, menu_item: item)
+
         yield if block_given?
         return item
       else

--- a/app/services/data_conversion_tool/menu_item_importer.rb
+++ b/app/services/data_conversion_tool/menu_item_importer.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module DataConversionTool
+  class MenuItemImporter < BaseImporter
+    def initialize(menu:, logs: nil, errors: nil, skipped_keys: nil)
+      super(logs: logs, errors: errors, skipped_keys: skipped_keys)
+      @menu = menu
+    end
+
+    def import(data:)
+      name = data['name']
+      price = data['price']
+
+      if MenuItem.exists?(name: name)
+        handle_duplicate_item(name: name, price: price)
+      else
+        create_item(name: name, price: price)
+      end
+    end
+
+    private
+
+    def handle_duplicate_item(name:, price:)
+      new_name = "#{name} (duplicate #{SecureRandom.hex(3)})"
+      @menu.menu_items.create!(name: new_name, price: price)
+      logs << Logs.duplicate_item_warning(name, new_name)
+    end
+
+    def create_item(name:, price:)
+      @menu.menu_items.create!(name: name, price: price)
+      logs << Logs.menu_item_success(name)
+    end
+  end
+end

--- a/app/services/data_conversion_tool/menu_item_importer.rb
+++ b/app/services/data_conversion_tool/menu_item_importer.rb
@@ -2,8 +2,8 @@
 
 module DataConversionTool
   class MenuItemImporter < BaseImporter
-    def initialize(menu:, logs: nil, errors: nil, skipped_keys: nil)
-      super(logs: logs, errors: errors, skipped_keys: skipped_keys)
+    def initialize(menu:, created_records: nil, skipped_records: nil, logs: nil, errors: nil, skipped_keys: nil)
+      super(logs: logs, created_records: created_records, skipped_records: skipped_records, errors: errors, skipped_keys: skipped_keys)
       @menu = menu
     end
 
@@ -12,23 +12,36 @@ module DataConversionTool
       price = data['price']
 
       if MenuItem.exists?(name: name)
-        handle_duplicate_item(name: name, price: price)
+        new_name = "#{name} (duplicate #{SecureRandom.hex(3)})"
+        create_item(name: new_name, price: price) do
+          @created_records[:duplicated_items] += 1
+          logs << Logs.duplicate_item_warning(name, new_name)
+        end
       else
-        create_item(name: name, price: price)
+        create_item(name: name, price: price) do
+          @created_records[:items] += 1
+          logs << Logs.menu_item_success(name)
+        end
       end
     end
 
     private
 
-    def handle_duplicate_item(name:, price:)
-      new_name = "#{name} (duplicate #{SecureRandom.hex(3)})"
-      @menu.menu_items.create!(name: new_name, price: price)
-      logs << Logs.duplicate_item_warning(name, new_name)
-    end
-
     def create_item(name:, price:)
-      @menu.menu_items.create!(name: name, price: price)
-      logs << Logs.menu_item_success(name)
+      item = @menu.menu_items.new(name: name, price: price)
+
+      if item.save
+        yield if block_given?
+        return item
+      else
+        @errors << Logs.menu_item_creation_failed(name, price, item.errors.full_messages.to_sentence)
+        @skipped_records[:items] += 1
+      end
+
+      nil
+    rescue StandardError => e
+      @errors << Logs.menu_item_creation_exception(name, price, e.message)
+      nil
     end
   end
 end

--- a/app/services/data_conversion_tool/restaurant_importer.rb
+++ b/app/services/data_conversion_tool/restaurant_importer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DataConversionTool
   class RestaurantImporter < BaseImporter
     def import(parsed_json)

--- a/app/services/data_conversion_tool/restaurant_importer.rb
+++ b/app/services/data_conversion_tool/restaurant_importer.rb
@@ -2,27 +2,49 @@
 
 module DataConversionTool
   class RestaurantImporter < BaseImporter
-    ALLOWED_KEYS = %w[name menus].freeze
+    ALLOWED_RESTAURANT_KEYS = %w[restaurants].freeze
 
     def import(parsed_json)
-      restaurants = parsed_json['restaurants']
-      return logs unless restaurants.is_a?(Array)
+      restaurants = extract_restaurants_from(parsed_json)
+      return { errors: @errors, logs: @logs } if restaurants.empty?
 
       restaurants.each { |restaurant_data| import_restaurant(data: restaurant_data) }
       summarize_logs
-      logs
+
+      {
+        created_records: @created_records,
+        skipped_records: @skipped_records,
+        errors: @errors,
+        skipped_keys: @skipped_keys,
+        logs: @logs
+      }
     end
 
     private
 
-    def import_restaurant(data:)
-      handle_unexpected_keys(data)
+    def extract_restaurants_from(data)
+      restaurant_key = data.keys.find { |key| self.class::ALLOWED_RESTAURANT_KEYS.include?(key) }
 
+      return handle_missing_root_key unless restaurant_key
+
+      data[restaurant_key]
+    end
+
+    def handle_missing_root_key
+      @errors << Logs.missing_restaurants_key_error(self.class::ALLOWED_RESTAURANT_KEYS)
+      []
+    end
+
+    def import_restaurant(data:)
       restaurant = create_restaurant(name: data['name'])
+      return unless restaurant
+
       menus = data['menus'] || []
 
       menu_importer = MenuImporter.new(
         restaurant: restaurant,
+        created_records: @created_records,
+        skipped_records: @skipped_records,
         logs: logs,
         errors: errors,
         skipped_keys: skipped_keys
@@ -31,15 +53,22 @@ module DataConversionTool
       menus.each { |menu_data| menu_importer.import(data: menu_data) }
     end
 
-    def handle_unexpected_keys(data)
-      KeyFinder.find(data, allowed_keys: ALLOWED_KEYS)
-      skipped_keys.merge(KeyFinder.unknown_keys)
-    end
-
     def create_restaurant(name:)
-      restaurant = Restaurant.create!(name: name)
-      logs << Logs.restaurant_success(name)
-      restaurant
+      restaurant = Restaurant.new(name: name)
+
+      if restaurant.save
+        @logs << Logs.restaurant_success(name)
+        @created_records[:restaurants] += 1
+        return restaurant
+      else
+        @errors << Logs.restaurant_creation_failed(name, restaurant.errors.full_messages.to_sentence)
+        @skipped_records[:restaurants] += 1
+      end
+
+      nil
+    rescue StandardError => e
+      @errors << Logs.restaurant_creation_exception(name, e.message)
+      nil
     end
   end
 end

--- a/app/services/data_conversion_tool/restaurant_importer.rb
+++ b/app/services/data_conversion_tool/restaurant_importer.rb
@@ -9,15 +9,8 @@ module DataConversionTool
       return { errors: @errors, logs: @logs } if restaurants.empty?
 
       restaurants.each { |restaurant_data| import_restaurant(data: restaurant_data) }
-      summarize_logs
 
-      {
-        created_records: @created_records,
-        skipped_records: @skipped_records,
-        errors: @errors,
-        skipped_keys: @skipped_keys,
-        logs: @logs
-      }
+      summarize_result
     end
 
     private
@@ -69,6 +62,17 @@ module DataConversionTool
     rescue StandardError => e
       @errors << Logs.restaurant_creation_exception(name, e.message)
       nil
+    end
+
+    def summarize_result
+      summarize_logs
+      {
+        created_records: @created_records,
+        skipped_records: @skipped_records,
+        errors: @errors,
+        skipped_keys: @skipped_keys,
+        logs: @logs
+      }
     end
   end
 end

--- a/app/services/data_conversion_tool/restaurant_importer.rb
+++ b/app/services/data_conversion_tool/restaurant_importer.rb
@@ -2,6 +2,8 @@
 
 module DataConversionTool
   class RestaurantImporter < BaseImporter
+    ALLOWED_KEYS = %w[name menus].freeze
+
     def import(parsed_json)
       restaurants = parsed_json['restaurants']
       return logs unless restaurants.is_a?(Array)
@@ -14,6 +16,8 @@ module DataConversionTool
     private
 
     def import_restaurant(data:)
+      handle_unexpected_keys(data)
+
       restaurant = create_restaurant(name: data['name'])
       menus = data['menus'] || []
 
@@ -25,6 +29,11 @@ module DataConversionTool
       )
 
       menus.each { |menu_data| menu_importer.import(data: menu_data) }
+    end
+
+    def handle_unexpected_keys(data)
+      KeyFinder.find(data, allowed_keys: ALLOWED_KEYS)
+      skipped_keys.merge(KeyFinder.unknown_keys)
     end
 
     def create_restaurant(name:)

--- a/app/services/data_conversion_tool/restaurant_importer.rb
+++ b/app/services/data_conversion_tool/restaurant_importer.rb
@@ -1,0 +1,100 @@
+module DataConversionTool
+  class RestaurantImporter < BaseImporter
+    include DataConversionTool::Helpers
+
+    def import(parsed_json)
+      @logs = []
+      @errors = []
+      @skipped_keys = Set.new
+
+      restaurants = parsed_json['restaurants']
+      return @logs unless restaurants.is_a?(Array)
+
+      restaurants.each { |restaurant| import_restaurant(data: restaurant) }
+
+      summarize_logs
+      @logs
+    end
+
+    private
+
+    def import_restaurant(data:)
+      restaurant_name = data['name']
+      restaurant_menus = data['menus']
+
+      restaurant = create_restaurant(name: restaurant_name)
+
+      menus = restaurant_menus || []
+      menus.each { |menu| import_menu(data: menu, restaurant: restaurant) }
+    end
+
+    def create_restaurant(name:)
+      restaurant = Restaurant.create!(name: name)
+      @logs << Logs.restaurant_success(name)
+      restaurant
+    end
+
+    def import_menu(data:, restaurant:)
+      menu_name = data['name']
+
+      return @errors << Logs.menu_warning(menu_name, restaurant.name) if restaurant.menus.exists?(name: menu_name)
+
+      menu = create_menu(name: menu_name, restaurant: restaurant)
+
+      key = KeyFinder.find(data)
+      return handle_missing_items_key(data.keys) unless key
+
+      items = wrap_in_array(data[key])
+      items.each { |item| import_item(data: item, menu: menu) }
+    end
+
+    def create_menu(name:, restaurant:)
+      menu = restaurant.menus.create!(name: name)
+      @logs << Logs.menu_success(name, restaurant.name)
+      menu
+    end
+
+    def handle_missing_items_key(keys)
+      @errors << Logs.missing_items_key_error
+      @skipped_keys.merge(keys - KeyFinder::ALLOWED_ITEM_KEYS)
+    end
+
+    def wrap_in_array(value)
+      value.is_a?(Array) ? value : [value]
+    end
+
+    def import_item(data:, menu:)
+      name = data['name']
+      price = data['price']
+
+      if MenuItem.exists?(name: name)
+        handle_duplicate_item(name: name, price: price, menu: menu)
+      else
+        create_item(name: name, price: price, menu: menu)
+      end
+    end
+
+    def handle_duplicate_item(name:, price:, menu:)
+      new_name = "#{name} (duplicate #{SecureRandom.hex(3)})"
+      menu.menu_items.create!(name: new_name, price: price)
+      @logs << Logs.duplicate_item_warning(name, new_name)
+    end
+
+    def create_item(name:, price:, menu:)
+      menu.menu_items.create!(name: name, price: price)
+      @logs << Logs.menu_item_success(name)
+    end
+
+    def summarize_logs
+      unless @errors.empty?
+        @logs << Logs.summarize_warnings_title
+        @logs.concat(@errors)
+      end
+
+      return if @skipped_keys.empty?
+
+      @logs << Logs.unknown_keys_title
+      @logs.concat(@skipped_keys.to_a.sort.map { |k| "  - #{k}" })
+    end
+  end
+end

--- a/app/services/data_conversion_tool/restaurant_importer.rb
+++ b/app/services/data_conversion_tool/restaurant_importer.rb
@@ -1,100 +1,34 @@
 module DataConversionTool
   class RestaurantImporter < BaseImporter
-    include DataConversionTool::Helpers
-
     def import(parsed_json)
-      @logs = []
-      @errors = []
-      @skipped_keys = Set.new
-
       restaurants = parsed_json['restaurants']
-      return @logs unless restaurants.is_a?(Array)
+      return logs unless restaurants.is_a?(Array)
 
-      restaurants.each { |restaurant| import_restaurant(data: restaurant) }
-
+      restaurants.each { |restaurant_data| import_restaurant(data: restaurant_data) }
       summarize_logs
-      @logs
+      logs
     end
 
     private
 
     def import_restaurant(data:)
-      restaurant_name = data['name']
-      restaurant_menus = data['menus']
+      restaurant = create_restaurant(name: data['name'])
+      menus = data['menus'] || []
 
-      restaurant = create_restaurant(name: restaurant_name)
+      menu_importer = MenuImporter.new(
+        restaurant: restaurant,
+        logs: logs,
+        errors: errors,
+        skipped_keys: skipped_keys
+      )
 
-      menus = restaurant_menus || []
-      menus.each { |menu| import_menu(data: menu, restaurant: restaurant) }
+      menus.each { |menu_data| menu_importer.import(data: menu_data) }
     end
 
     def create_restaurant(name:)
       restaurant = Restaurant.create!(name: name)
-      @logs << Logs.restaurant_success(name)
+      logs << Logs.restaurant_success(name)
       restaurant
-    end
-
-    def import_menu(data:, restaurant:)
-      menu_name = data['name']
-
-      return @errors << Logs.menu_warning(menu_name, restaurant.name) if restaurant.menus.exists?(name: menu_name)
-
-      menu = create_menu(name: menu_name, restaurant: restaurant)
-
-      key = KeyFinder.find(data)
-      return handle_missing_items_key(data.keys) unless key
-
-      items = wrap_in_array(data[key])
-      items.each { |item| import_item(data: item, menu: menu) }
-    end
-
-    def create_menu(name:, restaurant:)
-      menu = restaurant.menus.create!(name: name)
-      @logs << Logs.menu_success(name, restaurant.name)
-      menu
-    end
-
-    def handle_missing_items_key(keys)
-      @errors << Logs.missing_items_key_error
-      @skipped_keys.merge(keys - KeyFinder::ALLOWED_ITEM_KEYS)
-    end
-
-    def wrap_in_array(value)
-      value.is_a?(Array) ? value : [value]
-    end
-
-    def import_item(data:, menu:)
-      name = data['name']
-      price = data['price']
-
-      if MenuItem.exists?(name: name)
-        handle_duplicate_item(name: name, price: price, menu: menu)
-      else
-        create_item(name: name, price: price, menu: menu)
-      end
-    end
-
-    def handle_duplicate_item(name:, price:, menu:)
-      new_name = "#{name} (duplicate #{SecureRandom.hex(3)})"
-      menu.menu_items.create!(name: new_name, price: price)
-      @logs << Logs.duplicate_item_warning(name, new_name)
-    end
-
-    def create_item(name:, price:, menu:)
-      menu.menu_items.create!(name: name, price: price)
-      @logs << Logs.menu_item_success(name)
-    end
-
-    def summarize_logs
-      unless @errors.empty?
-        @logs << Logs.summarize_warnings_title
-        @logs.concat(@errors)
-      end
-
-      return if @skipped_keys.empty?
-
-      @logs << Logs.unknown_keys_title
-      @logs.concat(@skipped_keys.to_a.sort.map { |k| "  - #{k}" })
     end
   end
 end

--- a/bin/import_json
+++ b/bin/import_json
@@ -2,10 +2,26 @@
 
 require_relative '../config/environment'
 
+BLUE = "\e[34m"
 GREEN = "\e[32m"
-YELLOW = "\e[33m"
 RED = "\e[31m"
+YELLOW = "\e[33m"
 RESET = "\e[0m"
+
+if ARGV.include?('-h') || ARGV.include?('--help')
+  puts <<~HELP
+    #{YELLOW}Usage: bin/import_json path/to/file.json#{RESET}
+
+    Imports restaurants, menus, and menu items from a JSON file.
+
+    Options:
+      -h, --help        Show this help message
+
+    Example:
+      bin/import_json spec/fixtures/files/sample.json
+  HELP
+  exit(0)
+end
 
 if ARGV.empty?
   puts "#{YELLOW}Usage: bin/import_json path/to/file.json#{RESET}"
@@ -25,7 +41,7 @@ begin
     exit(1)
   end
 
-  puts "\n#{GREEN}✓ Import completed!"
+  puts "\n#{BLUE}!Import completed!"
   puts "#{GREEN}✓ Created:"
   result[:created_records].each { | key, value | puts "  - #{key}: #{value}" }
 
@@ -37,6 +53,23 @@ begin
   if result[:errors].any?
     puts "\n#{RED}X Errors:"
     result[:errors].each { | error | puts "  - #{error}" }
+  end
+
+  if result[:logs]&.any?
+    puts "\n#{BLUE}-- Logs --"
+    result[:logs].each do | log |
+      colored_log =
+        if log.include?("[✓ SUCCESS]")
+          "#{GREEN}#{log}#{RESET}"
+        elsif log.include?("[⚠ WARNING]")
+          "#{YELLOW}#{log}#{RESET}"
+        elsif log.include?("[X ERROR]")
+          "#{RED}#{log}#{RESET}"
+        else
+          log
+        end
+      puts "  #{colored_log}"
+    end
   end
 rescue => e
   puts "\n#{RED}! Import failed: #{e.message}#{RESET}"

--- a/bin/import_json
+++ b/bin/import_json
@@ -8,17 +8,24 @@ RED = "\e[31m"
 YELLOW = "\e[33m"
 RESET = "\e[0m"
 
+silent_mode = ARGV.include?('--silent')
+logs_only_mode = ARGV.include?('--logs-only')
+
 if ARGV.include?('-h') || ARGV.include?('--help')
   puts <<~HELP
-    #{YELLOW}Usage: bin/import_json path/to/file.json#{RESET}
+    #{BLUE}Usage: bin/import_json path/to/file.json [options]#{RESET}
 
     Imports restaurants, menus, and menu items from a JSON file.
 
     Options:
       -h, --help        Show this help message
+      --silent          Run in silent mode (no logs, just basic output)
+      --logs-only       Print only the logs
 
     Example:
       bin/import_json spec/fixtures/files/sample.json
+      bin/import_json spec/fixtures/files/sample.json --silent
+      bin/import_json spec/fixtures/files/sample.json --logs-only
   HELP
   exit(0)
 end
@@ -42,33 +49,37 @@ begin
   end
 
   puts "\n#{BLUE}!Import completed!"
-  puts "#{GREEN}✓ Created:"
-  result[:created_records].each { | key, value | puts "  - #{key}: #{value}" }
+  unless logs_only_mode
+    puts "#{GREEN}✓ Created:"
+    result[:created_records].each { | key, value | puts "  - #{key}: #{value}" }
 
-  if result[:skipped_records].any?
-    puts "\n#{YELLOW}⚠ Skipped:"
-    result[:skipped_records].each { | key, value | puts "  - #{key}: #{value}" }
+    if result[:skipped_records].any?
+      puts "\n#{YELLOW}⚠ Skipped:"
+      result[:skipped_records].each { | key, value | puts "  - #{key}: #{value}" }
+    end
+
+    if result[:errors].any?
+      puts "\n#{RED}X Errors:"
+      result[:errors].each { | error | puts "  - #{error}" }
+    end
   end
 
-  if result[:errors].any?
-    puts "\n#{RED}X Errors:"
-    result[:errors].each { | error | puts "  - #{error}" }
-  end
-
-  if result[:logs]&.any?
-    puts "\n#{BLUE}-- Logs --"
-    result[:logs].each do | log |
-      colored_log =
-        if log.include?("[✓ SUCCESS]")
-          "#{GREEN}#{log}#{RESET}"
-        elsif log.include?("[⚠ WARNING]")
-          "#{YELLOW}#{log}#{RESET}"
-        elsif log.include?("[X ERROR]")
-          "#{RED}#{log}#{RESET}"
-        else
-          log
-        end
-      puts "  #{colored_log}"
+  unless silent_mode
+    if result[:logs]&.any?
+      puts "\n#{BLUE}-- Logs --"
+      result[:logs].each do | log |
+        colored_log =
+          if log.include?("[✓ SUCCESS]")
+            "#{GREEN}#{log}#{RESET}"
+          elsif log.include?("[⚠ WARNING]")
+            "#{YELLOW}#{log}#{RESET}"
+          elsif log.include?("[X ERROR]")
+            "#{RED}#{log}#{RESET}"
+          else
+            log
+          end
+        puts "  #{colored_log}"
+      end
     end
   end
 rescue => e

--- a/bin/import_json
+++ b/bin/import_json
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+
+require_relative '../config/environment'
+
+GREEN = "\e[32m"
+YELLOW = "\e[33m"
+RED = "\e[31m"
+RESET = "\e[0m"
+
+if ARGV.empty?
+  puts "#{YELLOW}Usage: bin/import_json path/to/file.json#{RESET}"
+  exit(1)
+end
+
+file_path = ARGV.first
+
+begin
+  data = DataConversionTool::BaseImporter.parse_json(file_path)
+  result = DataConversionTool::RestaurantImporter.new.import(data)
+
+  unless result[:created_records]
+    puts "\n#{RED}! Import failed:"
+    result[:errors].each { | error | puts "  - #{error}" }
+    puts "#{RESET}"
+    exit(1)
+  end
+
+  puts "\n#{GREEN}✓ Import completed!"
+  puts "#{GREEN}✓ Created:"
+  result[:created_records].each { | key, value | puts "  - #{key}: #{value}" }
+
+  if result[:skipped_records].any?
+    puts "\n#{YELLOW}⚠ Skipped:"
+    result[:skipped_records].each { | key, value | puts "  - #{key}: #{value}" }
+  end
+
+  if result[:errors].any?
+    puts "\n#{RED}X Errors:"
+    result[:errors].each { | error | puts "  - #{error}" }
+  end
+rescue => e
+  puts "\n#{RED}! Import failed: #{e.message}#{RESET}"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,4 +17,6 @@ Rails.application.routes.draw do
 
   resources :menu_items, only: %i[index show create update destroy]
   post 'menu_items/:id/assign_to_menu/:menu_id', to: 'menu_items#assign_to_menu', as: 'assign_to_menu'
+
+  post 'import', to: 'imports#create'
 end

--- a/spec/controllers/imports_controller_spec.rb
+++ b/spec/controllers/imports_controller_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ImportsController, type: :controller do
+  describe 'POST #create' do
+    subject { response }
+
+    let(:headers) { { 'CONTENT_TYPE' => 'multipart/form-data' } }
+
+    context 'with perfect data' do
+      let(:file) { fixture_file_upload(file_fixture('perfect_data.json')) }
+
+      before { post :create, params: { file: file } }
+
+      it { is_expected.to have_http_status(:ok) }
+
+      it 'returns success message' do
+        expect(json_response['status']).to eq('Success')
+      end
+    end
+
+    context 'with partially good data' do
+      let(:file) { fixture_file_upload(file_fixture('partially_good.json')) }
+
+      before { post :create, params: { file: file } }
+
+      it { is_expected.to have_http_status(:multi_status) }
+
+      it 'returns partial success message' do
+        expect(json_response['status']).to eq('Partially successful')
+      end
+    end
+
+    context 'with missing root key (invalid data)' do
+      let(:file) { fixture_file_upload(file_fixture('missing_root_key.json')) }
+
+      before { post :create, params: { file: file } }
+
+      it { is_expected.to have_http_status(:bad_request) }
+
+      it 'returns failed message' do
+        expect(json_response['status']).to eq('Failed')
+      end
+    end
+
+    context 'with invalid file param (no file uploaded)' do
+      before { post :create }
+
+      it { is_expected.to have_http_status(:bad_request) }
+
+      it 'returns error message' do
+        expect(json_response['error']).to include('Missing required parameter')
+      end
+    end
+
+    def json_response
+      response.parsed_body
+    end
+  end
+end

--- a/spec/factories/menu_entry.rb
+++ b/spec/factories/menu_entry.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :menu_entry do
+    menu
+    menu_item
+  end
+end

--- a/spec/fixtures/files/bad_data.json
+++ b/spec/fixtures/files/bad_data.json
@@ -1,0 +1,70 @@
+{
+  "restaurants": [
+    {
+      "name": "Poppo's Cafe",
+      "menus": [
+        {
+          "name": "lunch",
+          "menu_items": [
+            {
+              "name": "Burger",
+              "price": "Free"
+            },
+            {
+              "name": "",
+              "price": 5
+            }
+          ]
+        },
+        {
+          "name": "",
+          "menu_items": [
+            {
+              "name": "Burger",
+              "price": 15
+            },
+            {
+              "name": "Large Salad",
+              "price": 8
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "",
+      "menus": [
+        {
+          "name": "lunch",
+          "bad_name": [
+            {
+              "name": "Chicken Wings",
+              "price": 9
+            },
+            {
+              "name": "Burger",
+              "price": 9
+            },
+            {
+              "name": "Chicken Wings",
+              "price": 9
+            }
+          ]
+        },
+        {
+          "name": "dinner",
+          "dishes": [
+            {
+              "name": "Mega \"Burger\"",
+              "price": 22
+            },
+            {
+              "name": "Lobster Mac & Cheese",
+              "price": 31
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/files/missing_root_key.json
+++ b/spec/fixtures/files/missing_root_key.json
@@ -1,0 +1,35 @@
+{
+  "invalid": [
+    {
+      "name": "Poppo's Cafe",
+      "menus": [
+        {
+          "name": "lunch",
+          "menu_items": [
+            {
+              "name": "Burger",
+              "price": 9
+            },
+            {
+              "name": "Small Salad",
+              "price": 5
+            }
+          ]
+        },
+        {
+          "name": "dinner",
+          "menu_items": [
+            {
+              "name": "Burger",
+              "price": 15
+            },
+            {
+              "name": "Large Salad",
+              "price": 8
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/files/partially_good.json
+++ b/spec/fixtures/files/partially_good.json
@@ -1,0 +1,35 @@
+{
+  "restaurants": [
+    {
+      "name": "Poppo's Cafe",
+      "menus": [
+        {
+          "name": "lunch",
+          "menu_items": [
+            {
+              "name": "Burger",
+              "price": 9
+            },
+            {
+              "name": "Small Salad",
+              "price": 5
+            }
+          ]
+        },
+        {
+          "name": "dinner",
+          "menu_items": [
+            {
+              "": "Ops",
+              "price": 15
+            },
+            {
+              "name": "Large Salad",
+              "price": 8
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/files/perfect_data.json
+++ b/spec/fixtures/files/perfect_data.json
@@ -1,0 +1,35 @@
+{
+  "restaurants": [
+    {
+      "name": "Poppo's Cafe",
+      "menus": [
+        {
+          "name": "lunch",
+          "menu_items": [
+            {
+              "name": "Burger",
+              "price": 9
+            },
+            {
+              "name": "Small Salad",
+              "price": 5
+            }
+          ]
+        },
+        {
+          "name": "dinner",
+          "menu_items": [
+            {
+              "name": "Another Burguer",
+              "price": 15
+            },
+            {
+              "name": "Large Salad",
+              "price": 8
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/files/restaurant_data.json
+++ b/spec/fixtures/files/restaurant_data.json
@@ -1,0 +1,70 @@
+{
+  "restaurants": [
+    {
+      "name": "Poppo's Cafe",
+      "menus": [
+        {
+          "name": "lunch",
+          "menu_items": [
+            {
+              "name": "Burger",
+              "price": 9
+            },
+            {
+              "name": "Small Salad",
+              "price": 5
+            }
+          ]
+        },
+        {
+          "name": "dinner",
+          "menu_items": [
+            {
+              "name": "Burger",
+              "price": 15
+            },
+            {
+              "name": "Large Salad",
+              "price": 8
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Casa del Poppo",
+      "menus": [
+        {
+          "name": "lunch",
+          "dishes": [
+            {
+              "name": "Chicken Wings",
+              "price": 9
+            },
+            {
+              "name": "Burger",
+              "price": 9
+            },
+            {
+              "name": "Chicken Wings",
+              "price": 9
+            }
+          ]
+        },
+        {
+          "name": "dinner",
+          "dishes": [
+            {
+              "name": "Mega \"Burger\"",
+              "price": 22
+            },
+            {
+              "name": "Lobster Mac & Cheese",
+              "price": 31
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,6 +37,7 @@ end
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include SerializerHelpers
+  config.include ServiceLogMatchers
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [

--- a/spec/services/data_conversion_tool/base_importer_spec.rb
+++ b/spec/services/data_conversion_tool/base_importer_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DataConversionTool::BaseImporter do
+  subject(:importer) do
+    Class.new(described_class) do
+      def import(_json)
+        # no operation, just a mock for testing
+      end
+    end.new(
+      logs:,
+      errors:,
+      skipped_keys:,
+      created_records:,
+      skipped_records:
+    )
+  end
+
+  let(:logs) { [] }
+  let(:errors) { [] }
+  let(:skipped_keys) { Set.new(['unknown_key']) }
+  let(:created_records) { Hash.new(0) }
+  let(:skipped_records) { Hash.new(0) }
+
+  describe '#summarize_logs' do
+    context 'when there are errors and skipped keys' do
+      before do
+        errors << 'Something went wrong'
+        skipped_keys << 'unexpected_key'
+        importer.summarize_logs
+      end
+
+      it 'adds a warning section to the logs' do
+        expect(logs).to include(a_string_matching(/WARNINGS/i))
+        expect(logs).to include('Something went wrong')
+      end
+
+      it 'adds an unknown keys section to the logs' do
+        expect(logs).to include(a_string_matching(/Unknown keys/i))
+        expect(logs).to include(/- unknown_key/)
+        expect(logs).to include(/- unexpected_key/)
+      end
+    end
+
+    context 'when there are no errors or skipped keys' do
+      let(:skipped_keys) { Set.new }
+      let(:errors) { [] }
+
+      it 'does not modify the logs' do
+        expect { importer.summarize_logs }.not_to(change { logs })
+      end
+    end
+  end
+
+  describe '.parse_json' do
+    context 'with valid JSON file' do
+      let(:file_path) { Rails.root.join('spec/fixtures/files/restaurant_data.json') }
+
+      it 'returns a parsed hash' do
+        parsed = described_class.parse_json(file_path)
+        expect(parsed).to be_a(Hash)
+        expect(parsed['restaurants']).to be_an(Array)
+      end
+    end
+
+    context 'with invalid JSON file' do
+      let(:file_path) { Rails.root.join('spec/fixtures/files/invalid.json') }
+
+      before do
+        File.write(file_path, '{ this is not valid JSON }')
+      end
+
+      after do
+        FileUtils.rm(file_path)
+      end
+
+      it 'raises an error and logs it' do
+        expect(Rails.logger).to receive(:error).with(/JSON parsing failed/)
+        expect do
+          described_class.parse_json(file_path)
+        end.to raise_error('Invalid JSON file')
+      end
+    end
+  end
+end

--- a/spec/services/data_conversion_tool/base_importer_spec.rb
+++ b/spec/services/data_conversion_tool/base_importer_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe DataConversionTool::BaseImporter do
     context 'with valid JSON file' do
       let(:file_path) { Rails.root.join('spec/fixtures/files/restaurant_data.json') }
 
-      it 'returns a parsed hash' do
+      it 'returns a hash containing the restaurants key as an array' do
         parsed = described_class.parse_json(file_path)
         expect(parsed).to be_a(Hash)
         expect(parsed['restaurants']).to be_an(Array)
@@ -76,10 +76,13 @@ RSpec.describe DataConversionTool::BaseImporter do
       end
 
       it 'raises an error and logs it' do
-        expect(Rails.logger).to receive(:error).with(/JSON parsing failed/)
+        allow(Rails.logger).to receive(:error)
+
         expect do
           described_class.parse_json(file_path)
         end.to raise_error('Invalid JSON file')
+
+        expect(Rails.logger).to have_received(:error).with(/JSON parsing failed/)
       end
     end
   end

--- a/spec/services/data_conversion_tool/menu_importer_spec.rb
+++ b/spec/services/data_conversion_tool/menu_importer_spec.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DataConversionTool::MenuImporter do
+  include ServiceLogMatchers
+
+  describe '#import' do
+    subject(:import) { importer.import(data: data) }
+
+    let(:restaurant) { create(:restaurant) }
+    let(:created_records) { Hash.new(0) }
+    let(:skipped_records) { Hash.new(0) }
+    let(:errors) { [] }
+    let(:logs) { [] }
+    let(:skipped_keys) { Set.new }
+
+    let(:importer) do
+      described_class.new(
+        restaurant: restaurant,
+        created_records: created_records,
+        skipped_records: skipped_records,
+        logs: logs,
+        errors: errors,
+        skipped_keys: skipped_keys
+      )
+    end
+
+    context 'when data is valid' do
+      let(:data) do
+        {
+          'name' => 'Burgers',
+          'description' => 'Classic American burgers.',
+          'menu_items' => [
+            { 'name' => 'X-Burger', 'price' => 10.0 }
+          ]
+        }
+      end
+
+      it 'creates a menu' do
+        expect { import }.to change(restaurant.menus, :count).by(1)
+      end
+
+      it 'creates the associated menu item' do
+        import
+        menu = restaurant.menus.find_by(name: 'Burgers')
+        expect(menu.menu_items.count).to eq(1)
+      end
+
+      it 'increments created_records[:menus]' do
+        expect { import }.to change { created_records[:menus] }.by(1)
+      end
+
+      it 'persists the menu item with correct attributes' do
+        import
+        menu_item = restaurant.menus.first.menu_items.first
+        expect(menu_item.name).to eq('X-Burger')
+        expect(menu_item.price).to eq(10.0)
+      end
+
+      it 'does not add errors' do
+        import
+        expect(errors).to be_empty
+      end
+
+      it 'logs a success message' do
+        import
+        expect(logs.join).to include('✓ SUCCESS')
+      end
+    end
+
+    context 'when multiple menu items are provided' do
+      let(:data) do
+        {
+          'name' => 'Combo Menu',
+          'menu_items' => [
+            { 'name' => 'Burger', 'price' => 12.0 },
+            { 'name' => 'Fries', 'price' => 5.0 },
+            { 'name' => 'Soda', 'price' => 4.0 }
+          ]
+        }
+      end
+
+      it 'creates all menu items' do
+        import
+        menu = restaurant.menus.find_by(name: 'Combo Menu')
+        expect(menu.menu_items.count).to eq(3)
+        expect(menu.menu_items.map(&:name)).to contain_exactly('Burger', 'Fries', 'Soda')
+      end
+    end
+
+    context 'when menu items key is aliased (e.g. "dishes")' do
+      let(:data) do
+        {
+          'name' => 'Burgers',
+          'dishes' => [
+            { 'name' => 'X-Burger', 'price' => 10.0 }
+          ]
+        }
+      end
+
+      it 'creates menu and associated item' do
+        expect { import }.to change(restaurant.menus, :count).by(1)
+        expect(created_records[:menus]).to eq(1)
+      end
+    end
+
+    context 'when some menu items are invalid' do
+      let(:data) do
+        {
+          'name' => 'Mixed Menu',
+          'menu_items' => [
+            { 'name' => 'Valid Item', 'price' => 12.0 },
+            { 'name' => '', 'price' => 5.0 },
+            { 'price' => 7.0 },
+            { 'name' => 'Negative', 'price' => -2.0 }
+          ]
+        }
+      end
+
+      it 'creates only the valid items' do
+        import
+        menu = restaurant.menus.find_by(name: 'Mixed Menu')
+        expect(menu.menu_items.count).to eq(1)
+        expect(menu.menu_items.first.name).to eq('Valid Item')
+      end
+
+      it 'logs errors for the invalid items' do
+        import
+        expect(errors.join).to include('Price must be greater than or equal to 0')
+      end
+
+      it 'increments skipped_records[:items]' do
+        import
+        expect(skipped_records[:items]).to eq(3)
+      end
+    end
+
+    context 'when menu already exists for the same restaurant' do
+      before do
+        create(:menu, name: 'Burgers', restaurant: restaurant)
+      end
+
+      let(:data) do
+        {
+          'name' => 'Burgers',
+          'menu_items' => [{ 'name' => 'X-Burger', 'price' => 10.0 }]
+        }
+      end
+
+      it 'does not create a new menu' do
+        expect { import }.not_to change(restaurant.menus, :count)
+      end
+
+      it 'adds a warning to errors' do
+        import
+        expect(errors.join).to include('already exists for restaurant')
+      end
+    end
+
+    context 'when data is missing "name"' do
+      let(:data) do
+        {
+          'description' => 'Missing name',
+          'menu_items' => [{ 'name' => 'X-Burger', 'price' => 10.0 }]
+        }
+      end
+
+      it 'does not create a menu' do
+        expect { import }.not_to change(restaurant.menus, :count)
+      end
+
+      it 'adds error about missing name' do
+        import
+        expect(errors.join).to include('Name can\'t be blank')
+        expect(skipped_records[:menus]).to eq(1)
+      end
+    end
+
+    context 'when "name" is present but empty' do
+      let(:data) do
+        {
+          'name' => '',
+          'menu_items' => [{ 'name' => 'X-Burger', 'price' => 10.0 }]
+        }
+      end
+
+      it 'does not create a menu' do
+        expect { import }.not_to change(restaurant.menus, :count)
+      end
+
+      it 'adds error about blank name' do
+        import
+        expect(errors.join).to include('Name can\'t be blank')
+        expect(skipped_records[:menus]).to eq(1)
+      end
+    end
+
+    context 'when menu has no recognizable menu items key' do
+      let(:data) do
+        {
+          'name' => 'Drinks',
+          'stuff' => [{ 'name' => 'Coke', 'price' => 5.0 }],
+          'foo' => 'bar'
+        }
+      end
+
+      it 'creates the menu anyway' do
+        expect { import }.to change(restaurant.menus, :count).by(1)
+      end
+
+      it 'adds a warning to errors' do
+        import
+        expect(errors.join).to include('No valid items key found')
+      end
+
+      it 'does not create any menu items' do
+        import
+        menu = restaurant.menus.find_by(name: 'Drinks')
+        expect(menu.menu_items).to be_empty
+      end
+    end
+  end
+end

--- a/spec/services/data_conversion_tool/menu_importer_spec.rb
+++ b/spec/services/data_conversion_tool/menu_importer_spec.rb
@@ -54,8 +54,11 @@ RSpec.describe DataConversionTool::MenuImporter do
       it 'persists the menu item with correct attributes' do
         import
         menu_item = restaurant.menus.first.menu_items.first
-        expect(menu_item.name).to eq('X-Burger')
-        expect(menu_item.price).to eq(10.0)
+
+        aggregate_failures 'checking attributes' do
+          expect(menu_item.name).to eq('X-Burger')
+          expect(menu_item.price).to eq(10.0)
+        end
       end
 
       it 'does not add errors' do
@@ -81,11 +84,14 @@ RSpec.describe DataConversionTool::MenuImporter do
         }
       end
 
-      it 'creates all menu items' do
+      it 'creates all menu items with correct names' do
         import
         menu = restaurant.menus.find_by(name: 'Combo Menu')
-        expect(menu.menu_items.count).to eq(3)
-        expect(menu.menu_items.map(&:name)).to contain_exactly('Burger', 'Fries', 'Soda')
+
+        aggregate_failures 'menu item validations' do
+          expect(menu.menu_items.count).to eq(3)
+          expect(menu.menu_items.map(&:name)).to contain_exactly('Burger', 'Fries', 'Soda')
+        end
       end
     end
 
@@ -100,8 +106,10 @@ RSpec.describe DataConversionTool::MenuImporter do
       end
 
       it 'creates menu and associated item' do
-        expect { import }.to change(restaurant.menus, :count).by(1)
-        expect(created_records[:menus]).to eq(1)
+        aggregate_failures do
+          expect { import }.to change(restaurant.menus, :count).by(1)
+          expect(created_records[:menus]).to eq(1)
+        end
       end
     end
 
@@ -119,10 +127,12 @@ RSpec.describe DataConversionTool::MenuImporter do
       end
 
       it 'creates only the valid items' do
-        import
-        menu = restaurant.menus.find_by(name: 'Mixed Menu')
-        expect(menu.menu_items.count).to eq(1)
-        expect(menu.menu_items.first.name).to eq('Valid Item')
+        aggregate_failures do
+          import
+          menu = restaurant.menus.find_by(name: 'Mixed Menu')
+          expect(menu.menu_items.count).to eq(1)
+          expect(menu.menu_items.first.name).to eq('Valid Item')
+        end
       end
 
       it 'logs errors for the invalid items' do

--- a/spec/services/data_conversion_tool/menu_item_importer_spec.rb
+++ b/spec/services/data_conversion_tool/menu_item_importer_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DataConversionTool::MenuItemImporter do
+  include ServiceLogMatchers
+
+  describe '#import' do
+    subject(:import) { importer.import(data: data) }
+
+    let(:menu) { create(:menu) }
+    let(:created_records) { Hash.new(0) }
+    let(:skipped_records) { Hash.new(0) }
+    let(:errors) { [] }
+    let(:logs) { [] }
+    let(:skipped_keys) { Set.new }
+    let(:importer) do
+      described_class.new(
+        menu: menu,
+        created_records: created_records,
+        skipped_records: skipped_records,
+        logs: logs,
+        errors: errors,
+        skipped_keys: skipped_keys
+      )
+    end
+
+    context 'when data is valid' do
+      let(:data) { { 'name' => 'X-Burger', 'price' => 12.5 } }
+
+      it 'creates a menu item' do
+        expect { import }.to change(menu.menu_items, :count).by(1)
+      end
+
+      it 'increments created_records[:items]' do
+        expect { import }.to change { created_records[:items] }.by(1)
+      end
+
+      it 'does not add any error' do
+        import
+        expect(errors).to be_empty
+      end
+
+      it 'logs success message' do
+        import
+        expect(logs).to include_log_message("    [✓ SUCCESS] MenuItem 'X-Burger' added")
+      end
+    end
+
+    context 'when item name is duplicated in the same menu' do
+      before { create(:menu_entry, menu: menu, menu_item: create(:menu_item, name: 'X-Burger')) }
+
+      let(:data) { { 'name' => 'X-Burger', 'price' => 9.99 } }
+
+      it 'creates a duplicated item with a modified name' do
+        expect { import }.to change(menu.menu_items, :count).by(1)
+        expect(menu.menu_items.last.name).to match(/X-Burger \(duplicate .+\)/)
+      end
+
+      it 'increments duplicated_items counter' do
+        expect { import }.to change { created_records[:duplicated_items] }.by(1)
+      end
+
+      it 'logs the duplication warning' do
+        import
+        expect(logs.any? { |log| log.include?('Duplicate item') }).to be true
+      end
+    end
+
+    context 'when name is missing' do
+      let(:data) { { 'price' => 10 } }
+
+      it 'does not create a menu item' do
+        expect { import }.not_to change(menu.menu_items, :count)
+      end
+
+      it 'increments skipped_records[:items]' do
+        expect { import }.to change { skipped_records[:items] }.by(1)
+      end
+
+      it 'adds an error' do
+        import
+        expect(errors.join).to match(/Failed to create MenuItem/)
+      end
+    end
+
+    context 'when price is missing' do
+      let(:data) { { 'name' => 'Fries' } }
+
+      it 'does not create a menu item' do
+        expect { import }.not_to change(menu.menu_items, :count)
+      end
+
+      it 'increments skipped_records[:items]' do
+        expect { import }.to change { skipped_records[:items] }.by(1)
+      end
+
+      it 'adds an error' do
+        import
+        expect(errors.join).to match(/Failed to create MenuItem/)
+      end
+    end
+
+    context 'when price is negative' do
+      let(:data) { { 'name' => 'Soup', 'price' => -3.0 } }
+
+      it 'does not create a menu item' do
+        expect { import }.not_to change(menu.menu_items, :count)
+      end
+
+      it 'adds an error and skips the item' do
+        expect { import }.to change { skipped_records[:items] }.by(1)
+        expect(errors.join).to match(/Failed to create MenuItem/)
+      end
+    end
+
+    context 'when price is not a number' do
+      let(:data) { { 'name' => 'Salad', 'price' => 'free' } }
+
+      it 'does not create a menu item' do
+        expect { import }.not_to change(menu.menu_items, :count)
+      end
+
+      it 'adds an error and skips the item' do
+        expect { import }.to change { skipped_records[:items] }.by(1)
+        expect(errors.join).to match(/Failed to create MenuItem/)
+      end
+    end
+
+    context 'when "name" key is invalid or missing' do
+      let(:data) { { 'nome' => 'InvalidKey', 'price' => 10 } }
+
+      it 'skips the item' do
+        expect { import }.to change { skipped_records[:items] }.by(1)
+        expect(menu.menu_items.count).to eq(0)
+      end
+    end
+
+    context 'when "price" key is invalid or missing' do
+      let(:data) { { 'name' => 'NoPrice', 'preco' => 99.99 } }
+
+      it 'skips the item' do
+        expect { import }.to change { skipped_records[:items] }.by(1)
+        expect(menu.menu_items.count).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/services/data_conversion_tool/menu_item_importer_spec.rb
+++ b/spec/services/data_conversion_tool/menu_item_importer_spec.rb
@@ -144,5 +144,30 @@ RSpec.describe DataConversionTool::MenuItemImporter do
         expect(menu.menu_items.count).to eq(0)
       end
     end
+
+    context 'when menu is nil (orphan menu item)' do
+      let(:importer) do
+        described_class.new(
+          menu: nil,
+          created_records: created_records,
+          skipped_records: skipped_records,
+          logs: logs,
+          errors: errors,
+          skipped_keys: skipped_keys
+        )
+      end
+
+      let(:data) { { 'name' => 'Orphan Item', 'price' => 9.99 } }
+
+      it 'does not raise an error and logs orphan menu item' do
+        expect { importer.import(data: data) }.not_to raise_error
+
+        expect(errors).to include(
+          a_string_matching(/MenuItem 'Orphan Item'.*menu was missing/)
+        )
+
+        expect(skipped_records[:items]).to eq(1)
+      end
+    end
   end
 end

--- a/spec/services/data_conversion_tool/restaurant_importer_spec.rb
+++ b/spec/services/data_conversion_tool/restaurant_importer_spec.rb
@@ -74,10 +74,12 @@ RSpec.describe DataConversionTool::RestaurantImporter do
       end
 
       it 'delegates menu import to MenuImporter' do
-        expect_any_instance_of(DataConversionTool::MenuImporter).to receive(:import)
-          .with(data: { 'name' => 'Lunch', 'items' => [] })
+        spy = instance_spy(DataConversionTool::MenuImporter)
+        allow(DataConversionTool::MenuImporter).to receive(:new).and_return(spy)
 
         importer.import(json)
+
+        expect(spy).to have_received(:import).with(data: { 'name' => 'Lunch', 'items' => [] })
       end
     end
 

--- a/spec/services/data_conversion_tool/restaurant_importer_spec.rb
+++ b/spec/services/data_conversion_tool/restaurant_importer_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DataConversionTool::RestaurantImporter do
+  subject(:importer) do
+    described_class.new(
+      created_records:,
+      skipped_records:,
+      logs:,
+      errors:,
+      skipped_keys:
+    )
+  end
+
+  let(:created_records) { Hash.new(0) }
+  let(:skipped_records) { Hash.new(0) }
+  let(:logs) { [] }
+  let(:errors) { [] }
+  let(:skipped_keys) { [] }
+
+  describe '#import' do
+    context 'when the root key is missing' do
+      let(:json) { { 'invalid_key' => [] } }
+
+      before { importer.import(json) }
+
+      it 'returns an empty array' do
+        expect(errors).not_to be_empty
+      end
+
+      it 'includes a descriptive error message' do
+        expect(errors.join).to include('Missing required root key')
+      end
+    end
+
+    context 'when there is one valid restaurant without menus' do
+      let(:json) { { 'restaurants' => [{ 'name' => 'Sushi Town' }] } }
+
+      it 'creates a new restaurant' do
+        expect do
+          importer.import(json)
+        end.to change(Restaurant, :count).by(1)
+      end
+
+      it 'increments created_records[:restaurants]' do
+        importer.import(json)
+        expect(created_records[:restaurants]).to eq(1)
+      end
+
+      it 'does not add errors' do
+        importer.import(json)
+        expect(errors).to be_empty
+      end
+
+      it 'logs restaurant creation' do
+        importer.import(json)
+        expect(logs.join).to include('SUCCESS')
+      end
+    end
+
+    context 'when the restaurant has nested menus' do
+      let(:json) do
+        {
+          'restaurants' => [
+            {
+              'name' => 'Burger Heaven',
+              'menus' => [
+                { 'name' => 'Lunch', 'items' => [] }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'delegates menu import to MenuImporter' do
+        expect_any_instance_of(DataConversionTool::MenuImporter).to receive(:import)
+          .with(data: { 'name' => 'Lunch', 'items' => [] })
+
+        importer.import(json)
+      end
+    end
+
+    context 'when restaurant creation fails due to validation' do
+      let(:json) { { 'restaurants' => [{ 'name' => '' }] } }
+
+      it 'does not create a restaurant' do
+        expect do
+          importer.import(json)
+        end.not_to change(Restaurant, :count)
+      end
+
+      it 'increments skipped_records[:restaurants]' do
+        importer.import(json)
+        expect(skipped_records[:restaurants]).to eq(1)
+      end
+
+      it 'logs the failure' do
+        importer.import(json)
+        expect(errors.join).to include('Failed to create restaurant')
+      end
+    end
+
+    context 'when an exception occurs during creation' do
+      let(:json) { { 'restaurants' => [{ 'name' => 'Boom' }] } }
+
+      before do
+        allow(Restaurant).to receive(:new).and_raise(StandardError.new('Something exploded'))
+      end
+
+      it 'rescues the exception and logs the error' do
+        importer.import(json)
+        expect(errors.join).to include('Unexpected error creating restaurant')
+        expect(errors.join).to include('Something exploded')
+      end
+    end
+  end
+end

--- a/spec/support/service_log_matchers.rb
+++ b/spec/support/service_log_matchers.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module ServiceLogMatchers
+  extend RSpec::Matchers::DSL
+
+  matcher :include_log_message do |expected_message|
+    match do |actual_logs|
+      actual_logs.include?(expected_message)
+    end
+
+    failure_message do |actual_logs|
+      <<~MSG
+        expected logs to include:
+          #{expected_message.inspect}
+        but got:
+          #{actual_logs.join("\n")}
+      MSG
+    end
+
+    failure_message_when_negated do |_actual_logs|
+      <<~MSG
+        expected logs not to include:
+          #{expected_message.inspect}
+        but it was found.
+      MSG
+    end
+
+    description do
+      "include log message: #{expected_message}"
+    end
+  end
+end


### PR DESCRIPTION
## Description

### Objective

This PR introduces two new ways to import restaurant's data into the system: via a dedicated API endpoint (`POST /import`) and through a command-line script (`bin/import_json`).

___

### Technical Details

To properly import data from a JSON file, there was the need to develop an internal import tools that would parse, validate, and persist data from this given file.

**New Services:**
- Created internal importer classes to handle JSON parsing and data persistence: BaseImporter, RestaurantImporter, MenuImporter, and MenuItemImporter.
- Each importer is responsible for its respective model and handles validation, logging, and tracking of created and skipped records.
- MenuItem will automatically rename duplicates when necessary.

**API Endpoint:**
- Created `POST /import` endpoint to import a JSON file via multipart/form-data.
- Handles file upload, parses its content, and returns a summary of the import process.

**CLI Tool:**
- Added a command-line script `bin/import_json` to import data from a JSON file.
- Supports --silent, --logs-only, and --help flags for a more flexible output control.
- Provides colored terminal output and import statistics (created, skipped, errors).

**Validations & Logging:**
- Ensures imported data respects all model validations.
- Logs duplicate items, skipped entries, and errors to provide transparency in the import process, and to better track those cases if the system is ever upgraded.

**Testing:**
- Added unit tests for all importer classes to validate behavior and edge cases.
- Verified error handling, duplication logic, and import summaries.
- There are now 169 tests.

**Other:**
- Updated the `README.md` with usage instructions for the CLI tool and the import endpoint.
- Documented the expected JSON structure and current import limitations.

___

### Notes for the Evaluator

This was by far the most challenging level. Dealing with unstructured external data meant a lot could go wrong, and time was tight—I only had Sunday to work with this level. So I focused on covering as much as possible, even if not exhaustively.

To handle inconsistent key names (like "menu-items" vs "dishes"), I implemented a flexible KeyFinder inspired by Python’s dict behavior. It supports a list of possible keys and logs unknown ones at the end of the import, so they can be added later. This way, there is space to improve the tool further with usage.

For duplicates (e.g. two MenuItems with the same name), since the final purpose of the API wasn’t entirely clear (I mean, there is no real final user), I opted for transparency and control: if a MenuItem name conflicts with existing data, a hash is appended to the name. This way, all data can still be imported, and users can decide how to handle duplicates later—similar to how CSV import works in tools like ClickUp or Linear.

It was my first time building an importer like this in Rails, so I had to look up best practices along the way. I used a service-like structure, though it doesn’t follow the ideal “single public method” pattern. Given the complexity, some refactoring would be needed to make it more idiomatic, but for this level I had just one day, so I focused on functionality and modularity. So if, in the future, the import tool needs to be upgrades to import only menus, or only a list of MenuItem, it can deal with it.

There were many architectural decisions that could have gone in different directions—like, for example, I could have decided to store logs in the database or create multi-steps for this import to the user can decide on-the-run—but I prioritized a clean, testable process over extra features. And I tried to keep the code flexible enough for future improvements.

Once everything was working, I wrote tests and more tests for each importer class and also ran multiple manual tests using the CLI. Time ran out in the end, I've finished that by 4 AM on Monday, but I’m happy I was able to "ship" a working, tested import flow within the deadline.

And that's it!
Thank you for your attention.